### PR TITLE
fixed how sort the paths by length

### DIFF
--- a/src/blocks.cpp
+++ b/src/blocks.cpp
@@ -8,7 +8,9 @@ smoothable_blocks(
     const uint64_t& max_block_weight,
     const uint64_t& max_path_jump,
     const uint64_t& min_subpath,
-    const uint64_t& max_edge_jump) {
+    const uint64_t& max_edge_jump,
+    const bool& order_paths_from_longest
+    ) {
     // iterate over the handles in their vectorized order, collecting blocks that we can potentially smooth
     std::vector<block_t> blocks;
     std::vector<std::vector<bool>> seen_steps;
@@ -139,13 +141,21 @@ smoothable_blocks(
             }
             //std::cerr << "max_path_length " << block.max_path_length << std::endl;
 
-            // order the path ranges from longest to shortest
+            // order the path ranges from longest/shortest to shortest/longest
             ips4o::parallel::sort(
                 block.path_ranges.begin(), block.path_ranges.end(),
+                order_paths_from_longest
+                ?
+                [](const path_range_t& a,
+                   const path_range_t& b) {
+                    return a.length > b.length;
+                }
+                :
                 [](const path_range_t& a,
                    const path_range_t& b) {
                     return a.length < b.length;
-                });
+                }
+                );
             /*
             std::cerr << "block----" << std::endl;
             for (auto& path_range : block.path_ranges) {

--- a/src/blocks.cpp
+++ b/src/blocks.cpp
@@ -144,7 +144,7 @@ smoothable_blocks(
             // order the path ranges from longest/shortest to shortest/longest
             ips4o::parallel::sort(
                 block.path_ranges.begin(), block.path_ranges.end(),
-                order_paths_from_longest
+                order_paths_from_longest || block.path_ranges.size() > 128
                 ?
                 [](const path_range_t& a,
                    const path_range_t& b) {

--- a/src/blocks.hpp
+++ b/src/blocks.hpp
@@ -43,6 +43,7 @@ smoothable_blocks(
     const uint64_t& max_block_weight,
     const uint64_t& max_path_jump,
     const uint64_t& min_subpath,
-    const uint64_t& max_edge_jump);
+    const uint64_t& max_edge_jump,
+    const bool& order_paths_from_longest);
 
 }

--- a/src/breaks.cpp
+++ b/src/breaks.cpp
@@ -12,7 +12,8 @@ void break_blocks(const xg::XG& graph,
                   const uint64_t& min_copy_length,
                   const uint64_t& max_copy_length,
                   const uint64_t& min_autocorr_z,
-                  const uint64_t& autocorr_stride) {
+                  const uint64_t& autocorr_stride,
+                  const bool& order_paths_from_longest) {
 
     const VectorizableHandleGraph& vec_graph = dynamic_cast<const VectorizableHandleGraph&>(graph);
 
@@ -119,12 +120,21 @@ void break_blocks(const xg::XG& graph,
             }
         }
         block.path_ranges = chopped_ranges;
+        // order the path ranges from longest/shortest to shortest/longest
         ips4o::parallel::sort(
             block.path_ranges.begin(), block.path_ranges.end(),
+            order_paths_from_longest
+            ?
+            [](const path_range_t& a,
+               const path_range_t& b) {
+                return a.length > b.length;
+            }
+            :
             [](const path_range_t& a,
                const path_range_t& b) {
                 return a.length < b.length;
-            });
+            }
+        );
     }
     std::cerr << "[smoothxg::break_blocks] cut " << n_cut_blocks << " blocks of which " << n_repeat_blocks << " had repeats" << std::endl;
 }

--- a/src/breaks.cpp
+++ b/src/breaks.cpp
@@ -123,7 +123,7 @@ void break_blocks(const xg::XG& graph,
         // order the path ranges from longest/shortest to shortest/longest
         ips4o::parallel::sort(
             block.path_ranges.begin(), block.path_ranges.end(),
-            order_paths_from_longest
+            order_paths_from_longest || block.path_ranges.size() > 128
             ?
             [](const path_range_t& a,
                const path_range_t& b) {

--- a/src/breaks.hpp
+++ b/src/breaks.hpp
@@ -25,6 +25,7 @@ void break_blocks(const xg::XG& graph,
                   const uint64_t& min_copy_length,
                   const uint64_t& max_copy_length,
                   const uint64_t& min_autocorr_z,
-                  const uint64_t& autocorr_stride);
+                  const uint64_t& autocorr_stride,
+                  const bool& order_paths_from_longest);
 
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -121,7 +121,7 @@ int main(int argc, char** argv) {
                                               max_block_weight,
                                               max_block_jump,
                                               min_subpath,
-                                              max_edge_jump);
+                                              max_edge_jump, !args::get(use_abpoa));
 
     uint64_t min_autocorr_z = 5;
     uint64_t autocorr_stride = 50;
@@ -131,7 +131,7 @@ int main(int argc, char** argv) {
                            min_copy_length,
                            max_copy_length,
                            min_autocorr_z,
-                           autocorr_stride);
+                           autocorr_stride, !args::get(use_abpoa));
 
     auto smoothed = smoothxg::smooth_and_lace(graph,
                                               blocks,

--- a/src/smooth.cpp
+++ b/src/smooth.cpp
@@ -352,15 +352,17 @@ odgi::graph_t smooth_and_lace(const xg::XG &graph,
 
     paryfor::parallel_for<uint64_t>(
         0, blocks.size(), thread_count, [&](uint64_t block_id, int tid) {
+            auto &block = blocks[block_id];
+
             { // if (block_id % 100 == 0) {
                 std::lock_guard<std::mutex> guard(logging_mutex);
                 std::cerr
-                    << "[smoothxg::smooth_and_lace] applying abPOA to block "
-                    << block_id << "/" << blocks.size() << " " << std::fixed
+                    << "[smoothxg::smooth_and_lace] applying " << (use_abpoa && block.path_ranges.size() <= 128 ? "abPOA" : "SPOA")
+                    << " to block " << block_id << "/" << blocks.size() << " " << std::fixed
                     << std::showpoint << std::setprecision(3)
                     << (float)block_id / (float)blocks.size() * 100 << "%\r";
             }
-            auto &block = blocks[block_id];
+
             std::string consensus_name =
                 consensus_base_name + std::to_string(block_id);
             // std::cerr << "on block " << block_id+1 << " of " << blocks.size()
@@ -452,8 +454,8 @@ odgi::graph_t smooth_and_lace(const xg::XG &graph,
             }
         });
 
-    std::cerr << "[smoothxg::smooth_and_lace] applying spoa to block "
-              << blocks.size() << "/" << blocks.size() << " " << std::fixed
+    std::cerr << "[smoothxg::smooth_and_lace] applying " << (use_abpoa ? "abPOA" : "SPOA")
+              << " to block " << blocks.size() << "/" << blocks.size() << " " << std::fixed
               << std::showpoint << std::setprecision(3) << 100.0 << "%"
               << std::endl;
 


### PR DESCRIPTION
Paths were always sorted from shortest to longest, leading to bad results applying `SPOA`:

```
abpoa -s -r 3 DRB1-3123.fa.gz > DRB1-3123.abpoa-s.gfa
master/smoothxg -g DRB1-3123.abpoa-s.gfa -t 16 -w 1000000 -l 1000000 -e 10000000 -j 10000000 > x.gfa  && odgi build -g x.gfa -o x.og -s &&  odgi layout -i x.og -o x.lay -t 16 -P && odgi draw -i x.og -c x.lay -p x.png
```

![branch sorting_from_shortest_with_spoa](https://user-images.githubusercontent.com/62253982/94745272-a986a880-037a-11eb-93a6-0a557b6dda3c.png)

With this PR:
- when `SPOA` is applied for smoothing blocks, the paths are sorted from the longest to the shortest.

```
smoothxg -g DRB1-3123.abpoa-s.gfa -t 16 -w 1000000 -l 1000000 -e 10000000 -j 10000000 > x.gfa  && odgi build -g x.gfa -o x.og -s &&  odgi layout -i x.og -o x.lay -t 16 -P && odgi draw -i x.og -c x.lay -p x.png
```

![branch sorting_from_longest_with_spoa](https://user-images.githubusercontent.com/62253982/94745424-f5395200-037a-11eb-894b-84f131fba5fb.png)


- when `abPOA` is applied for smoothing blocks, the paths are sorted from the shortest to the longest.

```
smoothxg -g DRB1-3123.abpoa-s.gfa -t 16 -w 1000000 -l 1000000 -e 10000000 -j 10000000 --abpoa > x.gfa  && odgi build -g x.gfa -o x.og -s &&  odgi layout -i x.og -o x.lay -t 16 -P && odgi draw -i x.og -c x.lay -p x.png
```

![branch abpoa_from_shortest](https://user-images.githubusercontent.com/62253982/94745951-05056600-037c-11eb-9e02-cf47b5b86de6.png)

This is because when using `abPOA`, starting with the longest sequences seems to lead to worse results:

![branch abpoa_from_longest](https://user-images.githubusercontent.com/62253982/94746015-25cdbb80-037c-11eb-8d23-9e2b084d9ca7.png)
