### PR TITLE
bugfix when traversing abPOA graph

### DIFF
--- a/src/smooth.cpp
+++ b/src/smooth.cpp
@@ -794,8 +794,7 @@ void build_odgi_abPOA(abpoa_t *ab, abpoa_para_t *abpt, odgi::graph_t &output,
                     while (num) {
                         tmp = num & -num;
                         read_id = ilog2_64(abpt, tmp);
-                        read_paths[read_id][read_path_i[read_id]++] =
-                            cur_id - 1;
+                        read_paths[b+read_id][read_path_i[b+read_id]++] = cur_id - 1;
                         num ^= tmp;
                     }
                     b += 64;


### PR DESCRIPTION
This updates the transition of abPOA graph to odgi graph as fixed in @yangao07's https://github.com/yangao07/abPOA/commit/865e7285fac162e0b83eff83615782461894bc1d.