### PR TITLE
Erase empty blocks

### DIFF
--- a/src/blocks.cpp
+++ b/src/blocks.cpp
@@ -223,6 +223,15 @@ smoothable_blocks(
     if (blocks.back().path_ranges.empty()) {
         finalize_block(blocks.back());
     }
+
+    blocks.erase(
+        std::remove_if(
+            blocks.begin(), blocks.end(),
+            [&](const block_t& block) {
+                return block.total_path_length == 0;
+            }),
+        blocks.end());
+
     // at the end, we'll be left with some fragments of paths that aren't included in any blocks
     // that's ok, but we should see how much of a problem it is / should they be compressed?
     return blocks;


### PR DESCRIPTION
We shouldn't have lots of empty blocks. It's just confusing. Erasing them is easy and only helps.