### PR TITLE
No limit abpoa

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,10 @@ The path-guided stochastic gradient descent based 1D sort implemented in `odgi s
 
 ## building
 
-`smoothxg` is built with cmake:
+`smoothxg` uses cmake to build itself and its dependencies.
 
-    cmake -H. -Bbuild && cmake --build build -- -j4
-
+```
+git clone --recursive https://github.com/pangenome/smoothxg.git
+cd smoothxg
+cmake -H. -Bbuild && cmake --build build -- -j 4
+```

--- a/src/blocks.cpp
+++ b/src/blocks.cpp
@@ -144,7 +144,7 @@ smoothable_blocks(
             // order the path ranges from longest/shortest to shortest/longest
             ips4o::parallel::sort(
                 block.path_ranges.begin(), block.path_ranges.end(),
-                order_paths_from_longest || block.path_ranges.size() > 128
+                order_paths_from_longest
                 ?
                 [](const path_range_t& a,
                    const path_range_t& b) {

--- a/src/blocks.hpp
+++ b/src/blocks.hpp
@@ -33,6 +33,7 @@ struct block_t {
     uint64_t total_path_length = 0;
     uint64_t max_path_length = 0;
     std::vector<path_range_t> path_ranges;
+    bool broken = false;
 };
 
 // find the boundaries of blocks that we can compress with spoa

--- a/src/blocks.hpp
+++ b/src/blocks.hpp
@@ -34,6 +34,7 @@ struct block_t {
     uint64_t max_path_length = 0;
     std::vector<path_range_t> path_ranges;
     bool broken = false;
+    bool is_repeat = false;
 };
 
 // find the boundaries of blocks that we can compress with spoa

--- a/src/breaks.cpp
+++ b/src/breaks.cpp
@@ -136,6 +136,7 @@ void break_blocks(const xg::XG& graph,
             }
         );
         block.broken = true;
+        block.is_repeat = found_repeat;
     }
     std::cerr << "[smoothxg::break_blocks] cut " << n_cut_blocks << " blocks of which " << n_repeat_blocks << " had repeats" << std::endl;
 }

--- a/src/breaks.cpp
+++ b/src/breaks.cpp
@@ -17,7 +17,7 @@ void break_blocks(const xg::XG& graph,
 
     const VectorizableHandleGraph& vec_graph = dynamic_cast<const VectorizableHandleGraph&>(graph);
 
-    std::cerr << "[smoothxg::break_blocks] cutting blocks that contain sequences above max-poa-length" << std::endl;
+    std::cerr << "[smoothxg::break_blocks] cutting blocks that contain sequences longer than max-poa-length (" << max_poa_length << ")" << std::endl;
 
     uint64_t n_cut_blocks = 0;
     uint64_t n_repeat_blocks = 0;
@@ -123,7 +123,7 @@ void break_blocks(const xg::XG& graph,
         // order the path ranges from longest/shortest to shortest/longest
         ips4o::parallel::sort(
             block.path_ranges.begin(), block.path_ranges.end(),
-            order_paths_from_longest || block.path_ranges.size() > 128
+            order_paths_from_longest
             ?
             [](const path_range_t& a,
                const path_range_t& b) {
@@ -135,6 +135,7 @@ void break_blocks(const xg::XG& graph,
                 return a.length < b.length;
             }
         );
+        block.broken = true;
     }
     std::cerr << "[smoothxg::break_blocks] cut " << n_cut_blocks << " blocks of which " << n_repeat_blocks << " had repeats" << std::endl;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -30,13 +30,13 @@ int main(int argc, char** argv) {
     args::ValueFlag<std::string> base(parser, "BASE", "use this basename for temporary files during build", {'b', "base"});
     args::Flag no_prep(parser, "bool", "do not prepare the graph for processing (prep is equivalent to odgi chop followed by odgi sort -p sYgs, and is disabled when taking XG input)", {'n', "no-prep"});
     args::Flag add_consensus(parser, "bool", "include consensus sequence in graph", {'a', "add-consensus"});
-    args::ValueFlag<uint64_t> _max_block_weight(parser, "N", "maximum seed sequence in block [default: 50000]", {'w', "max-block-weight"});
+    args::ValueFlag<uint64_t> _max_block_weight(parser, "N", "maximum seed sequence in block [default: 10000]", {'w', "max-block-weight"});
     args::ValueFlag<uint64_t> _max_block_jump(parser, "N", "maximum path jump to include in block [default: 5000]", {'j', "max-path-jump"});
     args::ValueFlag<uint64_t> _min_subpath(parser, "N", "minimum length of a subpath to include in partial order alignment [default: 16]", {'k', "min-subpath"});
-    args::ValueFlag<uint64_t> _max_edge_jump(parser, "N", "maximum edge jump before breaking [default: 1000]", {'e', "max-edge-jump"});
+    args::ValueFlag<uint64_t> _max_edge_jump(parser, "N", "maximum edge jump before breaking [default: 5000]", {'e', "max-edge-jump"});
     args::ValueFlag<uint64_t> _min_copy_length(parser, "N", "minimum repeat length to collapse [default: 1000]", {'c', "min-copy-length"});
     args::ValueFlag<uint64_t> _max_copy_length(parser, "N", "maximum repeat length to attempt to detect [default: 20000]", {'m', "max-copy-length"});
-    args::ValueFlag<uint64_t> _max_poa_length(parser, "N", "maximum sequence length to put into poa [default: 50000]", {'l', "max-poa-length"});
+    args::ValueFlag<uint64_t> _max_poa_length(parser, "N", "maximum sequence length to put into poa [default: 10000]", {'l', "max-poa-length"});
     args::ValueFlag<uint64_t> num_threads(parser, "N", "use this many threads during parallel steps", {'t', "threads"});
     args::ValueFlag<int> _poa_m(parser, "N", "poa score for matching bases [default: 2]", {'M', "poa-match"});
     args::ValueFlag<int> _poa_n(parser, "N", "poa penalty for mismatching bases [default: 4]", {'N', "poa-mismatch"});
@@ -97,13 +97,13 @@ int main(int argc, char** argv) {
         }
     }
 
-    uint64_t max_block_weight = _max_block_weight ? args::get(_max_block_weight) : 50000;
+    uint64_t max_block_weight = _max_block_weight ? args::get(_max_block_weight) : 10000;
     uint64_t max_block_jump = _max_block_jump ? args::get(_max_block_jump) : 5000;
     uint64_t min_subpath = _min_subpath ? args::get(_min_subpath) : 16;
-    uint64_t max_edge_jump = _max_edge_jump ? args::get(_max_edge_jump) : 1000;
+    uint64_t max_edge_jump = _max_edge_jump ? args::get(_max_edge_jump) : 5000;
     uint64_t min_copy_length = _min_copy_length ? args::get(_min_copy_length) : 1000;
     uint64_t max_copy_length = _max_copy_length ? args::get(_max_copy_length) : 20000;
-    uint64_t max_poa_length = _max_poa_length ? args::get(_max_poa_length) : 50000;
+    uint64_t max_poa_length = _max_poa_length ? args::get(_max_poa_length) : 10000;
 
     int poa_m = 2;
     int poa_n = 4;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -46,7 +46,9 @@ int main(int argc, char** argv) {
     args::ValueFlag<int> _poa_c(parser, "N", "poa gap extension penalty of the second affine function [default: 1]", {'C', "poa-2nd-gap-extend"});
     args::ValueFlag<int> _prep_node_chop(parser, "N", "during prep, chop nodes to this length [default: 100]", {'X', "chop-to"});
     args::ValueFlag<float> _prep_sgd_min_term_updates(parser, "N", "path-guided SGD sort quality parameter (N * sum_path_length updates per iteration) for graph prep [default: 1]", {'U', "path-sgd-term-updates"});
-    args::Flag use_spoa(parser, "use-spoa", "run spoa instead of abPOA for smoothing", {'S', "spoa"});
+    args::Flag use_spoa(parser, "use-spoa", "run spoa (in local alignment mode) instead of abPOA (in global alignment mode) for smoothing", {'S', "spoa"});
+    args::Flag global_alignment(parser, "global-alignment", "force global alignment in spoa (local is default)", {'Z', "global-alignment"});
+    args::Flag local_alignment(parser, "local-alignment", "force local alignment in abPOA (global is default except for broken blocks)", {'L', "local-alignment"});
     args::Flag no_toposort(parser, "no-toposort", "don't apply topological sorting in the sort pipeline", {'T', "no-toposort"});
     args::Flag validate(parser, "validate", "validate construction", {'V', "validate"});
     args::Flag keep_temp(parser, "keep-temp", "keep temporary files", {'K', "keep-temp"});
@@ -136,6 +138,13 @@ int main(int argc, char** argv) {
                            autocorr_stride,
                            order_paths_from_longest);
 
+    bool _local_alignment = false;
+    if (args::get(use_spoa)) {
+        _local_alignment = !args::get(global_alignment);
+    } else {
+        _local_alignment = args::get(local_alignment);
+    }
+
     auto smoothed = smoothxg::smooth_and_lace(graph,
                                               blocks,
                                               poa_m,
@@ -144,6 +153,7 @@ int main(int argc, char** argv) {
                                               poa_e,
                                               poa_q,
                                               poa_c,
+                                              _local_alignment,
                                               !args::get(use_spoa),
                                               args::get(add_consensus) ? "Consensus_" : "");
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -47,8 +47,7 @@ int main(int argc, char** argv) {
     args::ValueFlag<int> _prep_node_chop(parser, "N", "during prep, chop nodes to this length [default: 100]", {'X', "chop-to"});
     args::ValueFlag<float> _prep_sgd_min_term_updates(parser, "N", "path-guided SGD sort quality parameter (N * sum_path_length updates per iteration) for graph prep [default: 1]", {'U', "path-sgd-term-updates"});
     args::Flag use_spoa(parser, "use-spoa", "run spoa (in local alignment mode) instead of abPOA (in global alignment mode) for smoothing", {'S', "spoa"});
-    args::Flag global_alignment(parser, "global-alignment", "force global alignment in spoa (local is default)", {'Z', "global-alignment"});
-    args::Flag local_alignment(parser, "local-alignment", "force local alignment in abPOA (global is default except for broken blocks)", {'L', "local-alignment"});
+    args::Flag change_alignment_mode(parser, "change-alignment-mode", "change the alignment mode (global for spoa and local for abPOA)", {'Z', "change-alignment-mode"});
     args::Flag no_toposort(parser, "no-toposort", "don't apply topological sorting in the sort pipeline", {'T', "no-toposort"});
     args::Flag validate(parser, "validate", "validate construction", {'V', "validate"});
     args::Flag keep_temp(parser, "keep-temp", "keep temporary files", {'K', "keep-temp"});
@@ -138,13 +137,6 @@ int main(int argc, char** argv) {
                            autocorr_stride,
                            order_paths_from_longest);
 
-    bool _local_alignment = false;
-    if (args::get(use_spoa)) {
-        _local_alignment = !args::get(global_alignment);
-    } else {
-        _local_alignment = args::get(local_alignment);
-    }
-
     auto smoothed = smoothxg::smooth_and_lace(graph,
                                               blocks,
                                               poa_m,
@@ -153,7 +145,7 @@ int main(int argc, char** argv) {
                                               poa_e,
                                               poa_q,
                                               poa_c,
-                                              _local_alignment,
+                                              args::get(use_spoa) ^ args::get(change_alignment_mode),
                                               !args::get(use_spoa),
                                               args::get(add_consensus) ? "Consensus_" : "");
 

--- a/src/smooth.cpp
+++ b/src/smooth.cpp
@@ -365,6 +365,7 @@ odgi::graph_t smooth_and_lace(const xg::XG &graph,
                 std::lock_guard<std::mutex> guard(logging_mutex);
                 std::cerr
                     << "[smoothxg::smooth_and_lace] applying " << (use_abpoa ? "abPOA" : "SPOA")
+                    << " (" << (local_alignment ? "local" : "global") << " alignment mode)"
                     << " to block " << block_id << "/" << blocks.size() << " " << std::fixed
                     << std::showpoint << std::setprecision(3)
                     << (float)block_id / (float)blocks.size() * 100 << "%\r";
@@ -459,6 +460,7 @@ odgi::graph_t smooth_and_lace(const xg::XG &graph,
         });
 
     std::cerr << "[smoothxg::smooth_and_lace] applying " << (use_abpoa ? "abPOA" : "SPOA")
+              << " (" << (local_alignment ? "local" : "global") << " alignment mode)"
               << " to block " << blocks.size() << "/" << blocks.size() << " " << std::fixed
               << std::showpoint << std::setprecision(3) << 100.0 << "%"
               << std::endl;
@@ -626,7 +628,7 @@ odgi::graph_t smooth_and_lace(const xg::XG &graph,
         assert(orig_seq == smoothed_seq);
     });
 
-    if (consensus_mapping.size()) {
+    if (!consensus_mapping.empty()) {
         std::cerr << "[smoothxg::smooth_and_lace] sorting consensus"
                   << std::endl;
     }
@@ -642,7 +644,7 @@ odgi::graph_t smooth_and_lace(const xg::XG &graph,
     // by definition, the consensus paths are embedded in our blocks, which
     // simplifies things we'll still need to add a new path for each consensus
     // path
-    if (consensus_mapping.size()) {
+    if (!consensus_mapping.empty()) {
         std::cerr << "[smoothxg::smooth_and_lace] embedding consensus"
                   << std::endl;
     }
@@ -819,7 +821,7 @@ void build_odgi_abPOA(abpoa_t *ab, abpoa_para_t *abpt, odgi::graph_t &output,
         path_handle_t p;
         std::vector<handle_t> steps;
         std::uint32_t node_id;
-        if (sequence_names.size() != 0) {
+        if (!sequence_names.empty()) {
             // fprintf(stdout, "P\t%s\t", sequence_names[i]);
             // std::cerr << "P\t" << sequence_names[i] << "\t";
             p = output.create_path_handle(sequence_names[i]);
@@ -863,7 +865,7 @@ void build_odgi_abPOA(abpoa_t *ab, abpoa_para_t *abpt, odgi::graph_t &output,
         int id = abg->node[ABPOA_SRC_NODE_ID].max_out_id;
         // fprintf(stdout, "P\tConsensus_sequence\t");
         path_handle_t p = output.create_path_handle(consensus_name);
-        while (1) {
+        while (true) {
             // fprintf(stdout, "%d+", id-1);
             output.append_step(p, output.get_handle(id - 1));
             id = abg->node[id].max_out_id;

--- a/src/smooth.cpp
+++ b/src/smooth.cpp
@@ -101,7 +101,7 @@ odgi::graph_t smooth_abpoa(const xg::XG &graph, const block_t &block, const uint
     // initialize abPOA parameters
     abpoa_para_t *abpt = abpoa_init_para();
     // if we want to do local alignments
-    //abpt->align_mode = ABPOA_LOCAL_MODE;
+    if (block.broken) abpt->align_mode = ABPOA_LOCAL_MODE;
     //abpt->zdrop = 100; // could be useful in local mode
     //abpt->end_bonus = 100; // also useful in local mode
     abpt->rev_cigar = 0;
@@ -357,7 +357,7 @@ odgi::graph_t smooth_and_lace(const xg::XG &graph,
             { // if (block_id % 100 == 0) {
                 std::lock_guard<std::mutex> guard(logging_mutex);
                 std::cerr
-                    << "[smoothxg::smooth_and_lace] applying " << (use_abpoa && block.path_ranges.size() <= 128 ? "abPOA" : "SPOA")
+                    << "[smoothxg::smooth_and_lace] applying " << (use_abpoa ? "abPOA" : "SPOA")
                     << " to block " << block_id << "/" << blocks.size() << " " << std::fixed
                     << std::showpoint << std::setprecision(3)
                     << (float)block_id / (float)blocks.size() * 100 << "%\r";
@@ -369,7 +369,7 @@ odgi::graph_t smooth_and_lace(const xg::XG &graph,
             // << std::endl;
             auto &block_graph = block_graphs[block_id];
 
-            if (use_abpoa && block.path_ranges.size() <= 128) {
+            if (use_abpoa) {
                 block_graph = smooth_abpoa(graph,
                                            block,
                                            block_id,

--- a/src/smooth.cpp
+++ b/src/smooth.cpp
@@ -102,7 +102,7 @@ odgi::graph_t smooth_abpoa(const xg::XG &graph, const block_t &block, const uint
     // initialize abPOA parameters
     abpoa_para_t *abpt = abpoa_init_para();
     // if we want to do local alignments
-    if (local_alignment || block.broken) abpt->align_mode = ABPOA_LOCAL_MODE;
+    if (local_alignment) abpt->align_mode = ABPOA_LOCAL_MODE;
     //abpt->zdrop = 100; // could be useful in local mode
     //abpt->end_bonus = 100; // also useful in local mode
     abpt->rev_cigar = 0;

--- a/src/smooth.hpp
+++ b/src/smooth.hpp
@@ -49,7 +49,7 @@ odgi::graph_t smooth_and_lace(const xg::XG &graph,
                               int poa_m, int poa_n,
                               int poa_g, int poa_e,
                               int poa_q, int poa_c,
-                              bool use_abpoa = false,
+                              bool use_abpoa = true,
                               const std::string &consensus_name = "");
 
 void write_gfa(std::unique_ptr<spoa::Graph> &graph, std::ostream &out,

--- a/src/smooth.hpp
+++ b/src/smooth.hpp
@@ -35,13 +35,14 @@ struct path_position_range_t {
 odgi::graph_t smooth_abpoa(const xg::XG &graph, const block_t &block, const uint64_t &block_id,
                            int poa_m, int poa_n, int poa_g,
                            int poa_e, int poa_q, int poa_c,
+                           bool local_alignment,
                            const std::string &consensus_name = "");
 
 odgi::graph_t smooth_spoa(const xg::XG &graph, const block_t &block,
                           const uint64_t &block_id,
-                          std::unique_ptr<spoa::AlignmentEngine> &alignment_engine,
                           std::int8_t poa_m, std::int8_t poa_n, std::int8_t poa_g,
                           std::int8_t poa_e, std::int8_t poa_q, std::int8_t poa_c,
+                          bool local_alignment,
                           const std::string &consensus_name = "");
 
 odgi::graph_t smooth_and_lace(const xg::XG &graph,
@@ -49,6 +50,7 @@ odgi::graph_t smooth_and_lace(const xg::XG &graph,
                               int poa_m, int poa_n,
                               int poa_g, int poa_e,
                               int poa_q, int poa_c,
+                              bool local_alignment,
                               bool use_abpoa = true,
                               const std::string &consensus_name = "");
 


### PR DESCRIPTION
This integrates abPOA.

We use global mode except for broken blocks, where it appears that local mode is preferable due to the incomplete matching between path fragments overlapping the block.

Global and local mode are selectable, but the defaults are reversed for spoa and abPOA.