### PR TITLE
maf output and merged-consensus sequences embedding in the smoothed graph

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -236,7 +236,7 @@ add_library(smoothxg_objs OBJECT
   src/breaks.cpp
   src/smooth.cpp
   src/utils.cpp
-  ${sautocorr_INCLUDE}/sautocorr.cpp)
+  ${sautocorr_INCLUDE}/sautocorr.cpp src/maf.hpp)
 
 add_dependencies(smoothxg_objs handlegraph)
 add_dependencies(smoothxg_objs sdsl-lite)

--- a/src/blocks.hpp
+++ b/src/blocks.hpp
@@ -37,16 +37,6 @@ struct block_t {
     bool is_repeat = false;
 };
 
-struct maf_row_t {
-    std::string path_name;
-    uint64_t record_start;
-    uint64_t seq_size;
-    bool is_reversed;
-    uint64_t path_length;
-    std::string aligned_seq;
-};
-
-
 // find the boundaries of blocks that we can compress with spoa
 // assuming a maximum path length within each block
 std::vector<block_t>

--- a/src/blocks.hpp
+++ b/src/blocks.hpp
@@ -37,6 +37,16 @@ struct block_t {
     bool is_repeat = false;
 };
 
+struct maf_row_t {
+    std::string path_name;
+    uint64_t record_start;
+    uint64_t seq_size;
+    bool is_reversed;
+    uint64_t path_length;
+    std::string aligned_seq;
+};
+
+
 // find the boundaries of blocks that we can compress with spoa
 // assuming a maximum path length within each block
 std::vector<block_t>

--- a/src/maf.hpp
+++ b/src/maf.hpp
@@ -36,3 +36,32 @@ void write_maf_row(std::ofstream &out, const maf_row_t& row){
            std::to_string(row.path_length) + " " +
            row.aligned_seq + "\n";
 }
+
+void write_maf_rows(std::ofstream &out, const std::vector<maf_row_t>& rows) {
+    // determine output widths for everything
+    size_t max_src_length = 0;
+    size_t max_start_length = 0;
+    size_t max_seq_size_length = 0;
+    size_t max_is_rev_length = 1;
+    size_t max_src_size_length = 0;
+    size_t max_text_length = 0;
+    for (auto& row : rows) {
+        max_src_length = std::max(max_src_length, row.path_name.size());
+        max_start_length = std::max(max_start_length, std::to_string(row.record_start).size());
+        max_seq_size_length = std::max(max_seq_size_length, std::to_string(row.seq_size).size());
+        max_src_size_length = std::max(max_src_size_length, std::to_string(row.path_length).size());
+        max_text_length = std::max(max_text_length, row.aligned_seq.size());
+    }
+    // write and pad them
+    for (auto& row : rows) {
+        out << "s "
+            << row.path_name << std::string(max_src_length - row.path_name.size(), ' ')
+            << std::setw(max_start_length+1) << row.record_start
+            << std::setw(max_seq_size_length+1) << row.seq_size
+            << std::setw(max_is_rev_length+1) << row.is_reversed
+            << std::setw(max_src_size_length+1) << row.path_length
+            << " " << row.aligned_seq
+            << "\n";
+    }
+    out << std::endl;
+}

--- a/src/maf.hpp
+++ b/src/maf.hpp
@@ -28,15 +28,6 @@ struct maf_t {
     std::vector<std::pair<std::string, maf_partial_row_t>> consensus_rows;
 };
 
-void write_maf_row(std::ofstream &out, const maf_row_t& row){
-    out << "s " + row.path_name + " " +
-           std::to_string(row.record_start) + " " +
-           std::to_string(row.seq_size) +
-           (row.is_reversed ? " - " : " + ") +
-           std::to_string(row.path_length) + " " +
-           row.aligned_seq + "\n";
-}
-
 void write_maf_rows(std::ofstream &out, const std::vector<maf_row_t>& rows) {
     // determine output widths for everything
     size_t max_src_length = 0;
@@ -58,7 +49,7 @@ void write_maf_rows(std::ofstream &out, const std::vector<maf_row_t>& rows) {
             << row.path_name << std::string(max_src_length - row.path_name.size(), ' ')
             << std::setw(max_start_length+1) << row.record_start
             << std::setw(max_seq_size_length+1) << row.seq_size
-            << std::setw(max_is_rev_length+1) << row.is_reversed
+            << std::setw(max_is_rev_length+1) << (row.is_reversed ? " - " : " + ")
             << std::setw(max_src_size_length+1) << row.path_length
             << " " << row.aligned_seq
             << "\n";

--- a/src/maf.hpp
+++ b/src/maf.hpp
@@ -25,7 +25,7 @@ struct maf_partial_row_t {
 struct maf_t {
     std::vector<uint64_t> field_blocks;
     std::map<std::string, maf_partial_row_t> rows;
-    std::pair<std::string, maf_partial_row_t> consensus_row;
+    std::vector<std::pair<std::string, maf_partial_row_t>> consensus_rows;
 };
 
 void write_maf_row(std::ofstream &out, const maf_row_t& row){

--- a/src/maf.hpp
+++ b/src/maf.hpp
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <iostream>
+#include <fstream>
+#include <vector>
+#include <map>
+
+struct maf_row_t {
+    std::string path_name;
+    uint64_t record_start;
+    uint64_t seq_size;
+    bool is_reversed;
+    uint64_t path_length;
+    std::string aligned_seq;
+};
+
+struct maf_partial_row_t {
+    uint64_t record_start;
+    uint64_t seq_size;
+    bool is_reversed;
+    uint64_t path_length;
+    std::string aligned_seq;
+};
+
+struct maf_t {
+    std::vector<uint64_t> field_blocks;
+    std::map<std::string, maf_partial_row_t> rows;
+    std::pair<std::string, maf_partial_row_t> consensus_row;
+};
+
+void write_maf_row(std::ofstream &out, const maf_row_t& row){
+    out << "s " + row.path_name + " " +
+           std::to_string(row.record_start) + " " +
+           std::to_string(row.seq_size) +
+           (row.is_reversed ? " - " : " + ") +
+           std::to_string(row.path_length) + " " +
+           row.aligned_seq + "\n";
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -138,6 +138,8 @@ int main(int argc, char** argv) {
                            autocorr_stride,
                            order_paths_from_longest);
 
+    bool local_alignment = args::get(use_spoa) ^ args::get(change_alignment_mode);
+
     std::vector<std::string> mafs;
     auto smoothed = smoothxg::smooth_and_lace(graph,
                                               blocks,
@@ -147,7 +149,7 @@ int main(int argc, char** argv) {
                                               poa_e,
                                               poa_q,
                                               poa_c,
-                                              args::get(use_spoa) ^ args::get(change_alignment_mode),
+                                              local_alignment,
                                               write_msa_in_maf_format, mafs,
                                               !args::get(use_spoa),
                                               args::get(add_consensus) ? "Consensus_" : "");
@@ -167,8 +169,13 @@ int main(int argc, char** argv) {
         ofstream f(maf_output.c_str());
 
         f << "##maf version=1" << std::endl;
-        f << "# smoothxg (" << (args::get(use_spoa) ? "SPOA" : "abPOA") << ")" << std::endl;
-        f << "# input=" << filename << "\n" << std::endl;
+        f << "# smoothxg" << std::endl;
+        f << "# input=" << filename << std::endl;
+        f << "# POA=" << (args::get(use_spoa) ? "SPOA" : "abPOA") << " alignment_mode=" <<
+             (local_alignment ? "local" : "global") << std::endl;
+        f << "# max_block_weight=" << max_block_weight << " max_block_jump=" << max_block_jump <<
+             " min_subpath=" << min_subpath << " max_edge_jump=" << max_edge_jump << std::endl;
+        f << "\n" << std::endl;
 
         for(auto& maf : mafs){
             f << maf << std::endl;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -170,16 +170,6 @@ int main(int argc, char** argv) {
                 " min_subpath=" + std::to_string(min_subpath) +
                 " max_edge_jump=" + std::to_string(max_edge_jump) + "\n";
 
-        smoothxg::break_blocks(graph,
-                               blocks,
-                               max_poa_length,
-                               min_copy_length,
-                               max_copy_length,
-                               min_autocorr_z,
-                               autocorr_stride,
-                               order_paths_from_longest);
-
-
         // break_blocks
         maf_header += "# max_poa_length=" + std::to_string(max_poa_length) +
                 " min_copy_length=" + std::to_string(min_copy_length) +

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -29,6 +29,7 @@ int main(int argc, char** argv) {
     //args::ValueFlag<std::string> xg_out(parser, "FILE", "write the resulting xg index to this file", {'o', "out"});
     args::ValueFlag<std::string> xg_in(parser, "FILE", "read the xg index from this file", {'i', "in"});
     args::ValueFlag<std::string> write_msa_in_maf_format(parser, "FILE","write the multiple sequence alignments (MSAs) in MAF format in this file",{'m', "write-msa-in-maf-format"});
+    args::Flag do_not_merge_maf_blocks(parser, "bool","do not merge contiguous MAF blocks in the MAF output",{'M', "not-merge-maf-blocks"});
     args::ValueFlag<std::string> base(parser, "BASE", "use this basename for temporary files during build", {'b', "base"});
     args::Flag no_prep(parser, "bool", "do not prepare the graph for processing (prep is equivalent to odgi chop followed by odgi sort -p sYgs, and is disabled when taking XG input)", {'n', "no-prep"});
     args::Flag add_consensus(parser, "bool", "include consensus sequence in graph", {'a', "add-consensus"});
@@ -212,7 +213,7 @@ int main(int argc, char** argv) {
                                               poa_q,
                                               poa_c,
                                               local_alignment,
-                                              args::get(write_msa_in_maf_format), maf_header,
+                                              args::get(write_msa_in_maf_format), maf_header, args::get(do_not_merge_maf_blocks),
                                               !args::get(use_spoa),
                                               args::get(add_consensus) ? "Consensus_" : "");
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -175,7 +175,7 @@ int main(int argc, char** argv) {
              (local_alignment ? "local" : "global") << std::endl;
         f << "# max_block_weight=" << max_block_weight << " max_block_jump=" << max_block_jump <<
              " min_subpath=" << min_subpath << " max_edge_jump=" << max_edge_jump << std::endl;
-        f << "\n" << std::endl;
+        f << std::endl;
 
         for(auto& maf : mafs){
             f << maf << std::endl;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,7 +27,7 @@ int main(int argc, char** argv) {
     args::ValueFlag<std::string> gfa_in(parser, "FILE", "index the graph in this GFA file", {'g', "gfa-in"});
     //args::ValueFlag<std::string> xg_out(parser, "FILE", "write the resulting xg index to this file", {'o', "out"});
     args::ValueFlag<std::string> xg_in(parser, "FILE", "read the xg index from this file", {'i', "in"});
-    args::ValueFlag<std::string> write_msa_in_maf_format(parser, "FILE","write the multiple sequence alignments (MSAs) in MAF format in this file",{'W', "write-msa-in-maf-format"});
+    args::ValueFlag<std::string> write_msa_in_maf_format(parser, "FILE","write the multiple sequence alignments (MSAs) in MAF format in this file",{'m', "write-msa-in-maf-format"});
     args::ValueFlag<std::string> base(parser, "BASE", "use this basename for temporary files during build", {'b', "base"});
     args::Flag no_prep(parser, "bool", "do not prepare the graph for processing (prep is equivalent to odgi chop followed by odgi sort -p sYgs, and is disabled when taking XG input)", {'n', "no-prep"});
     args::Flag add_consensus(parser, "bool", "include consensus sequence in graph", {'a', "add-consensus"});
@@ -36,7 +36,7 @@ int main(int argc, char** argv) {
     args::ValueFlag<uint64_t> _min_subpath(parser, "N", "minimum length of a subpath to include in partial order alignment [default: 16]", {'k', "min-subpath"});
     args::ValueFlag<uint64_t> _max_edge_jump(parser, "N", "maximum edge jump before breaking [default: 5000]", {'e', "max-edge-jump"});
     args::ValueFlag<uint64_t> _min_copy_length(parser, "N", "minimum repeat length to collapse [default: 1000]", {'c', "min-copy-length"});
-    args::ValueFlag<uint64_t> _max_copy_length(parser, "N", "maximum repeat length to attempt to detect [default: 20000]", {'m', "max-copy-length"});
+    args::ValueFlag<uint64_t> _max_copy_length(parser, "N", "maximum repeat length to attempt to detect [default: 20000]", {'W', "max-copy-length"});
     args::ValueFlag<uint64_t> _max_poa_length(parser, "N", "maximum sequence length to put into poa [default: 10000]", {'l', "max-poa-length"});
     args::ValueFlag<uint64_t> num_threads(parser, "N", "use this many threads during parallel steps", {'t', "threads"});
     args::ValueFlag<int> _poa_m(parser, "N", "poa score for matching bases [default: 2]", {'M', "poa-match"});
@@ -180,8 +180,6 @@ int main(int argc, char** argv) {
     smoothed.to_gfa(std::cout);
     
     /*
-
-
     uint64_t block_id = 0;
     for (auto& block : blocks) {
         std::cout << "block" << block_id++ << "\t"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -197,7 +197,7 @@ int main(int argc, char** argv) {
 
         maf_header += "##maf version=1\n";
         maf_header += "# smoothxg\n";
-        maf_header += "# input=" + filename + "\n";
+        maf_header += "# input=" + filename + " sequences=" + std::to_string(graph.get_path_count()) + "\n";
 
         // POA
         maf_header += "# POA=";

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -28,11 +28,13 @@ int main(int argc, char** argv) {
     args::ValueFlag<std::string> gfa_in(parser, "FILE", "index the graph in this GFA file", {'g', "gfa-in"});
     //args::ValueFlag<std::string> xg_out(parser, "FILE", "write the resulting xg index to this file", {'o', "out"});
     args::ValueFlag<std::string> xg_in(parser, "FILE", "read the xg index from this file", {'i', "in"});
+
     args::ValueFlag<std::string> write_msa_in_maf_format(parser, "FILE","write the multiple sequence alignments (MSAs) in MAF format in this file",{'m', "write-msa-in-maf-format"});
-    args::Flag do_not_merge_maf_blocks(parser, "bool","do not merge contiguous MAF blocks in the MAF output",{'M', "not-merge-maf-blocks"});
+    args::Flag add_consensus(parser, "bool", "include consensus sequence in the smoothed graph", {'a', "add-consensus"});
+    args::Flag do_not_merge_blocks(parser, "bool","do not merge contiguous MAF blocks in the MAF output and consensus sequences in the smoothed graph",{'M', "not-merge-blocks"});
+
     args::ValueFlag<std::string> base(parser, "BASE", "use this basename for temporary files during build", {'b', "base"});
     args::Flag no_prep(parser, "bool", "do not prepare the graph for processing (prep is equivalent to odgi chop followed by odgi sort -p sYgs, and is disabled when taking XG input)", {'n', "no-prep"});
-    args::Flag add_consensus(parser, "bool", "include consensus sequence in graph", {'a', "add-consensus"});
     args::ValueFlag<uint64_t> _max_block_weight(parser, "N", "maximum seed sequence in block [default: 10000]", {'w', "max-block-weight"});
     args::ValueFlag<uint64_t> _max_block_jump(parser, "N", "maximum path jump to include in block [default: 5000]", {'j', "max-path-jump"});
     args::ValueFlag<uint64_t> _min_subpath(parser, "N", "minimum length of a subpath to include in partial order alignment [default: 0 / no filter]", {'k', "min-subpath"});
@@ -62,6 +64,12 @@ int main(int argc, char** argv) {
     }
     if (argc==1) {
         std::cout << parser;
+        return 1;
+    }
+
+    if (args::get(do_not_merge_blocks) && (!write_msa_in_maf_format && !args::get(add_consensus))) {
+        std::cerr << "[smoothxg::main] error: Please specify the -M/--not-merge-blocks-either to use the "
+                   "-m/--write-msa-in-maf-format and -a/--add-consensus options." << std::endl;
         return 1;
     }
 
@@ -213,7 +221,7 @@ int main(int argc, char** argv) {
                                               poa_q,
                                               poa_c,
                                               local_alignment,
-                                              args::get(write_msa_in_maf_format), maf_header, args::get(do_not_merge_maf_blocks),
+                                              args::get(write_msa_in_maf_format), maf_header, !args::get(do_not_merge_blocks),
                                               !args::get(use_spoa),
                                               args::get(add_consensus) ? "Consensus_" : "");
 

--- a/src/smooth.cpp
+++ b/src/smooth.cpp
@@ -349,6 +349,7 @@ odgi::graph_t smooth_spoa(const xg::XG &graph, const block_t &block,
 
             seq_size = seqs[seq_rank].size(); // <==> block.path_ranges[seq_rank].length
 
+            // ToDo: there is a problem when all sequences are reversed (?)
             min_path_range_begin = std::min(min_path_range_begin, path_range_begin);
         }else{
             // The last sequences is the consensus
@@ -384,6 +385,7 @@ odgi::graph_t smooth_and_lace(const xg::XG &graph,
                               int poa_g, int poa_e,
                               int poa_q, int poa_c,
                               bool local_alignment,
+                              bool write_msa_in_maf_format, std::vector<std::string> &mafs,
                               bool use_abpoa,
                               const std::string &consensus_base_name) {
 
@@ -393,7 +395,6 @@ odgi::graph_t smooth_and_lace(const xg::XG &graph,
     std::vector<odgi::graph_t> block_graphs;
     block_graphs.resize(blocks.size());
 
-    std::vector<std::string> mafs;
     mafs.resize(blocks.size());
 
     std::vector<path_position_range_t> path_mapping;

--- a/src/smooth.cpp
+++ b/src/smooth.cpp
@@ -707,7 +707,11 @@ odgi::graph_t smooth_and_lace(const xg::XG &graph,
                             }
 
                             if (produce_maf){
-                                out_maf << "a blocks=" << block_id_range << " loops=false" << std::endl;
+                                out_maf << "a blocks=" << block_id_range << " loops=false";
+                                if (merged_maf_blocks.field_blocks.size() > 1) {
+                                    out_maf << " merged=true";
+                                }
+                                out_maf << std::endl;
 
                                 std::vector<maf_row_t> rows;
                                 for (auto& maf_row : merged_maf_blocks.rows) {

--- a/src/smooth.cpp
+++ b/src/smooth.cpp
@@ -709,9 +709,9 @@ odgi::graph_t smooth_and_lace(const xg::XG &graph,
                             if (produce_maf){
                                 out_maf << "a blocks=" << block_id_range << " loops=false" << std::endl;
 
-                                for (auto& maf_row : merged_maf_blocks.rows){
-                                    write_maf_row(
-                                            out_maf,
+                                std::vector<maf_row_t> rows;
+                                for (auto& maf_row : merged_maf_blocks.rows) {
+                                    rows.push_back(
                                             {
                                                     maf_row.first,
                                                     maf_row.second.record_start,
@@ -740,8 +740,7 @@ odgi::graph_t smooth_and_lace(const xg::XG &graph,
                                         pos += maf_cons_row.second.aligned_seq.length();
                                         for (; pos < length_alignment; pos++){ gapped_cons += "-"; }
 
-                                        write_maf_row(
-                                                out_maf,
+                                        rows.push_back(
                                                 {
                                                         maf_cons_row.first,
                                                         maf_cons_row.second.record_start,
@@ -761,8 +760,7 @@ odgi::graph_t smooth_and_lace(const xg::XG &graph,
                                     }
 
                                     // Write the merged consensus
-                                    write_maf_row(
-                                            out_maf,
+                                    rows.push_back(
                                             {
                                                     consensus_base_name + block_id_range + " ",
                                                     merged_maf_blocks.consensus_rows.begin()->second.record_start,
@@ -775,7 +773,7 @@ odgi::graph_t smooth_and_lace(const xg::XG &graph,
 
                                     merged_consensus_aligned_seq.clear();
                                 }
-                                out_maf << std::endl;
+                                write_maf_rows(out_maf, rows);
                             }
 
 
@@ -796,13 +794,13 @@ odgi::graph_t smooth_and_lace(const xg::XG &graph,
                         if (!merged && !prep_new_merge_group) {
                             if (produce_maf){
                                 out_maf << "a blocks=" + std::to_string(block_id) << " loops=" << (contains_loops ? "true" : "false") << std::endl;
+                                std::vector<maf_row_t> rows;
                                 for (auto& maf_row : mafs[block_id]){
-                                    write_maf_row(
-                                            out_maf,
-                                            {maf_row.path_name, maf_row.record_start, maf_row.seq_size, maf_row.is_reversed, maf_row.path_length, maf_row.aligned_seq}
+                                    rows.push_back(
+                                        {maf_row.path_name, maf_row.record_start, maf_row.seq_size, maf_row.is_reversed, maf_row.path_length, maf_row.aligned_seq}
                                     );
                                 }
-                                out_maf << std::endl;
+                                write_maf_rows(out_maf, rows);
                             }
 
                             _clear_maf_block(block_id, mafs);

--- a/src/smooth.cpp
+++ b/src/smooth.cpp
@@ -609,20 +609,26 @@ odgi::graph_t smooth_and_lace(const xg::XG &graph,
             auto &block_graph = block_graphs[block_id];
 
             if (block_graph.get_node_count() > 0){
+                /*
+                std::string s = "smoothxg_block_" + std::to_string(block_id) + ".gfa";
+                std::ofstream gfa(s.c_str());
+                block_graph.to_gfa(gfa);
+                gfa.close();
+                */
+
                 bool contains_loops = false;
+                std::unordered_set<path_handle_t> seen_paths;
 
-                block_graph.for_each_handle([&](const handle_t &h) {
-                    std::unordered_set<path_handle_t> seen_paths;
-
-                    block_graph.for_each_step_on_handle(h, [&](const step_handle_t& step) {
-                        path_handle_t path = block_graph.get_path_handle_of_step(step);
-                        if (seen_paths.count(path)) {
-                            contains_loops = true;
-                        } else {
-                            seen_paths.insert(path);
-                        }
-                    });
-                });
+                for (auto &path_range : blocks[block_id].path_ranges){
+                    path_handle_t path = graph.get_path_handle_of_step(path_range.begin);
+                    if (seen_paths.count(path)) {
+                        contains_loops = true;
+                        break;
+                    } else {
+                        seen_paths.insert(path);
+                    }
+                }
+                seen_paths.clear();
 
                 f << "a block=" + std::to_string(block_id) << " loops=" << (contains_loops ? "true" : "false") << std::endl;
                 f << mafs[block_id] << std::endl;

--- a/src/smooth.cpp
+++ b/src/smooth.cpp
@@ -200,7 +200,9 @@ odgi::graph_t smooth_abpoa(const xg::XG &graph, const block_t &block, const uint
                 return smooth_abpoa(graph, block, block_id,
                                     poa_m, poa_n, poa_g,
                                     poa_e, poa_q, poa_c,
-                                    local_alignment, false,
+                                    local_alignment,
+                                    maf, keep_sequence,
+                                    false,
                                     consensus_name);
             }
         }

--- a/src/smooth.cpp
+++ b/src/smooth.cpp
@@ -321,15 +321,20 @@ odgi::graph_t smooth_spoa(const xg::XG &graph, const block_t &block,
     std::vector<std::string> msa;
     poa_graph->generate_multiple_sequence_alignment(msa);
 
+
     *maf += "a loops=false\n";
 
     for(uint64_t seq_rank = 0; seq_rank < msa.size(); seq_rank++){
-        *maf += "s " + names[seq_rank] + " " + "XXXSTART/ENDXXX"
+        auto path_handle = graph.get_path_handle_of_step(block.path_ranges[seq_rank].begin);
+
+        // If the strand field is "-" then this is the start relative to the reverse-complemented source sequence
+        uint64_t record_start = aln_is_reverse[seq_rank] ?
+                                graph.get_path_length(path_handle) - graph.get_position_of_step(block.path_ranges[seq_rank].begin) :
+                                graph.get_position_of_step(block.path_ranges[seq_rank].begin) ;
+
+        *maf += "s " + names[seq_rank] + " " + std::to_string(record_start)
                 + (aln_is_reverse[seq_rank] ? " - " : " + ") + std::to_string(seqs[seq_rank].size()) // <==> block.path_ranges[seq_rank].length
                 + " " + msa[seq_rank] + "\n";
-
-        //std::cerr << graph.get_id(graph.get_handle_of_step(block.path_ranges[seq_rank].begin)) << std::endl;
-                //<< " --- " << graph.get_id(graph.get_handle_of_step(block.path_ranges[seq_rank].end))
     }
 
     // write the graph, with consensus as a path
@@ -482,6 +487,21 @@ odgi::graph_t smooth_and_lace(const xg::XG &graph,
     for(auto& maf : mafs){
         std::cout << maf << std::endl;
     }
+    /*
+     * struct path_position_range_t {
+    path_handle_t base_path;   // base path in input graph
+    uint64_t start_pos;        // start position of the range
+    uint64_t end_pos;          // end position of the range
+    step_handle_t start_step;  // start step in the base graph
+    step_handle_t end_step;    // end step in the base graph
+    path_handle_t target_path; // target path in smoothed block graph
+    uint64_t target_graph_id;  // the block graph id
+
+
+     *
+    for (auto& x : path_mapping){
+        std::cerr << x.start_pos << " - " << x.end_pos << " --- " << x.target_graph_id << std::endl;
+    }*/
 
     std::cerr << "[smoothxg::smooth_and_lace] applying " << (use_abpoa ? "abPOA" : "SPOA")
               << " to block " << blocks.size() << "/" << blocks.size() << " " << std::fixed

--- a/src/smooth.cpp
+++ b/src/smooth.cpp
@@ -115,7 +115,7 @@ odgi::graph_t smooth_abpoa(const xg::XG &graph, const block_t &block, const uint
     abpt->out_gfa = 1; // must be set to get the graph
     abpt->out_msa = maf != nullptr ? 1 : 0; // must be set when we extract the MSA
     abpt->out_cons = generate_consensus;
-    abpt->amb_strand = 0; // we'll align both ways and check which is better
+    abpt->amb_strand = 1;
     abpt->match = poa_m;
     abpt->mismatch = poa_n;
     abpt->gap_open1 = poa_g;

--- a/src/smooth.cpp
+++ b/src/smooth.cpp
@@ -423,6 +423,8 @@ odgi::graph_t smooth_spoa(const xg::XG &graph, const block_t &block,
                     std::to_string(path_length) + " " +
                     msa[seq_rank] + "\n";
         }
+
+        msa.clear(); // Is this really necessary?
     }
 
     // write the graph, with consensus as a path

--- a/src/smooth.cpp
+++ b/src/smooth.cpp
@@ -509,8 +509,7 @@ odgi::graph_t smooth_and_lace(const xg::XG &graph,
                 consensus_name = consensus_base_name + std::to_string(block_id);
             }
 
-            // std::cerr << "on block " << block_id+1 << " of " << blocks.size()
-            // << std::endl;
+            // std::cerr << "on block " << block_id+1 << " of " << blocks.size() << std::endl;
             auto &block_graph = block_graphs[block_id];
 
             if (use_abpoa) {
@@ -631,12 +630,14 @@ odgi::graph_t smooth_and_lace(const xg::XG &graph,
             auto &b_id = as_integer(b.base_path);
             return (a_id < b_id || a_id == b_id && a.start_pos < b.start_pos);
         });
+
     // build the sequence and edges into the output graph
     odgi::graph_t smoothed;
+
     // add the nodes and edges to the graph
     std::vector<uint64_t> id_mapping;
-    std::cerr << "[smoothxg::smooth_and_lace] building final graph"
-              << std::endl;
+    std::cerr << "[smoothxg::smooth_and_lace] building final graph" << std::endl;
+
     uint64_t j = 0;
     for (auto &block : block_graphs) {
         uint64_t id_trans = smoothed.get_node_count();

--- a/src/smooth.cpp
+++ b/src/smooth.cpp
@@ -321,7 +321,6 @@ odgi::graph_t smooth_spoa(const xg::XG &graph, const block_t &block,
     std::vector<std::string> msa;
     poa_graph->generate_multiple_sequence_alignment(msa);
 
-
     *maf += "a loops=false\n";
 
     for(uint64_t seq_rank = 0; seq_rank < msa.size(); seq_rank++){
@@ -332,7 +331,7 @@ odgi::graph_t smooth_spoa(const xg::XG &graph, const block_t &block,
                                 graph.get_path_length(path_handle) - graph.get_position_of_step(block.path_ranges[seq_rank].begin) :
                                 graph.get_position_of_step(block.path_ranges[seq_rank].begin) ;
 
-        *maf += "s " + names[seq_rank] + " " + std::to_string(record_start)
+        *maf += "s " + graph.get_path_name(path_handle) + " " + std::to_string(record_start)
                 + (aln_is_reverse[seq_rank] ? " - " : " + ") + std::to_string(seqs[seq_rank].size()) // <==> block.path_ranges[seq_rank].length
                 + " " + msa[seq_rank] + "\n";
     }
@@ -487,21 +486,6 @@ odgi::graph_t smooth_and_lace(const xg::XG &graph,
     for(auto& maf : mafs){
         std::cout << maf << std::endl;
     }
-    /*
-     * struct path_position_range_t {
-    path_handle_t base_path;   // base path in input graph
-    uint64_t start_pos;        // start position of the range
-    uint64_t end_pos;          // end position of the range
-    step_handle_t start_step;  // start step in the base graph
-    step_handle_t end_step;    // end step in the base graph
-    path_handle_t target_path; // target path in smoothed block graph
-    uint64_t target_graph_id;  // the block graph id
-
-
-     *
-    for (auto& x : path_mapping){
-        std::cerr << x.start_pos << " - " << x.end_pos << " --- " << x.target_graph_id << std::endl;
-    }*/
 
     std::cerr << "[smoothxg::smooth_and_lace] applying " << (use_abpoa ? "abPOA" : "SPOA")
               << " to block " << blocks.size() << "/" << blocks.size() << " " << std::fixed

--- a/src/smooth.hpp
+++ b/src/smooth.hpp
@@ -42,7 +42,7 @@ odgi::graph_t smooth_spoa(const xg::XG &graph, const block_t &block,
                           std::unique_ptr<spoa::AlignmentEngine> &alignment_engine,
                           std::int8_t poa_m, std::int8_t poa_n, std::int8_t poa_g,
                           std::int8_t poa_e, std::int8_t poa_q, std::int8_t poa_c,
-                          std::string &maf, const std::string &consensus_name = "");
+                          std::string *maf, const std::string &consensus_name = "");
 
 odgi::graph_t smooth_and_lace(const xg::XG &graph,
                               const std::vector<block_t> &blocks,

--- a/src/smooth.hpp
+++ b/src/smooth.hpp
@@ -52,6 +52,7 @@ odgi::graph_t smooth_and_lace(const xg::XG &graph,
                               int poa_g, int poa_e,
                               int poa_q, int poa_c,
                               bool local_alignment,
+                              bool write_msa_in_maf_format, std::vector<std::string> &mafs,
                               bool use_abpoa = true,
                               const std::string &consensus_name = "");
 

--- a/src/smooth.hpp
+++ b/src/smooth.hpp
@@ -36,7 +36,7 @@ odgi::graph_t smooth_abpoa(const xg::XG &graph, const block_t &block, const uint
                            int poa_m, int poa_n, int poa_g,
                            int poa_e, int poa_q, int poa_c,
                            bool local_alignment,
-                           std::string *maf,
+                           bool write_msa_in_maf_format, std::string *maf,
                            const std::string &consensus_name = "");
 
 odgi::graph_t smooth_spoa(const xg::XG &graph, const block_t &block,

--- a/src/smooth.hpp
+++ b/src/smooth.hpp
@@ -42,7 +42,7 @@ odgi::graph_t smooth_spoa(const xg::XG &graph, const block_t &block,
                           std::unique_ptr<spoa::AlignmentEngine> &alignment_engine,
                           std::int8_t poa_m, std::int8_t poa_n, std::int8_t poa_g,
                           std::int8_t poa_e, std::int8_t poa_q, std::int8_t poa_c,
-                          const std::string &consensus_name = "");
+                          std::string &maf, const std::string &consensus_name = "");
 
 odgi::graph_t smooth_and_lace(const xg::XG &graph,
                               const std::vector<block_t> &blocks,

--- a/src/smooth.hpp
+++ b/src/smooth.hpp
@@ -53,7 +53,7 @@ odgi::graph_t smooth_and_lace(const xg::XG &graph,
                               int poa_g, int poa_e,
                               int poa_q, int poa_c,
                               bool local_alignment,
-                              std::string &path_output_maf, std::string &maf_header, bool do_not_merge_maf_blocks,
+                              std::string &path_output_maf, std::string &maf_header, bool merge_blocks,
                               bool use_abpoa = true,
                               const std::string &consensus_name = "");
 

--- a/src/smooth.hpp
+++ b/src/smooth.hpp
@@ -53,7 +53,7 @@ odgi::graph_t smooth_and_lace(const xg::XG &graph,
                               int poa_g, int poa_e,
                               int poa_q, int poa_c,
                               bool local_alignment,
-                              bool write_msa_in_maf_format, std::vector<std::string> &mafs,
+                              std::string &path_output_maf, std::string &maf_header,
                               bool use_abpoa = true,
                               const std::string &consensus_name = "");
 

--- a/src/smooth.hpp
+++ b/src/smooth.hpp
@@ -36,7 +36,7 @@ odgi::graph_t smooth_abpoa(const xg::XG &graph, const block_t &block, const uint
                            int poa_m, int poa_n, int poa_g,
                            int poa_e, int poa_q, int poa_c,
                            bool local_alignment,
-                           bool write_msa_in_maf_format, std::string *maf,
+                           std::string *maf,
                            const std::string &consensus_name = "");
 
 odgi::graph_t smooth_spoa(const xg::XG &graph, const block_t &block,
@@ -53,7 +53,7 @@ odgi::graph_t smooth_and_lace(const xg::XG &graph,
                               int poa_g, int poa_e,
                               int poa_q, int poa_c,
                               bool local_alignment,
-                              std::string &path_output_maf, std::string &maf_header,
+                              std::string &path_output_maf, std::string &maf_header, bool do_not_merge_maf_blocks,
                               bool use_abpoa = true,
                               const std::string &consensus_name = "");
 

--- a/src/smooth.hpp
+++ b/src/smooth.hpp
@@ -36,6 +36,7 @@ odgi::graph_t smooth_abpoa(const xg::XG &graph, const block_t &block, const uint
                            int poa_m, int poa_n, int poa_g,
                            int poa_e, int poa_q, int poa_c,
                            bool local_alignment,
+                           std::string *maf,
                            const std::string &consensus_name = "");
 
 odgi::graph_t smooth_spoa(const xg::XG &graph, const block_t &block,


### PR DESCRIPTION
This makes it possible, using the `-m` option, to output a MAF file with the MSAs obtained during the smoothing (`-m/--max-copy-length` becames `-W`).

**Little example (small.gfa)**
```
H	VN:Z:1.0
S	1	CAAATAAG
S	2	A
S	3	GCT
S	4	T
L	1	+	2	+	0M
L	2	+	3	+	0M
L	2	+	4	+	0M
P	x	1+,2+,3+	*
P	y	1+,2+,4+	*
```

Applying abPOA in global alignment mode:
```
smoothxg -g small.gfa -n -m out.maf && cat out.maf

##maf version=1
# smoothxg
# input=small.gfa
# POA=abPOA alignment_mode=global order_paths=from_shortest
# max_block_weight=10000 max_block_jump=5000 min_subpath=0 max_edge_jump=5000
# max_poa_length=10000 min_copy_length=1000 max_copy_length=20000 min_autocorr_z=5 autocorr_stride=50

a block=0 loops=false
s y 0 10 + 10 CAAATAAGA--T
s x 0 12 + 12 CAAATAAGAGCT
```

Applying SPOA in local alignment mode with a little `max_block_weight` and adding the consensus sequences:
```
smoothxg -g small.gfa -n -m out.maf -S -w 3 -a && cat out.maf

##maf version=1
# smoothxg
# input=small.gfa
# POA=SPOA alignment_mode=local order_paths=from_longest
# max_block_weight=3 max_block_jump=5000 min_subpath=0 max_edge_jump=5000
# max_poa_length=10000 min_copy_length=1000 max_copy_length=20000 min_autocorr_z=5 autocorr_stride=50

a block=0 loops=false
s x 0 9 + 12 CAAATAAGA
s y 0 9 + 10 CAAATAAGA
s Consensus_0 0 9 + 9 CAAATAAGA

a block=1 loops=false
s x 9 3 + 12 GCT
s y 9 1 + 10 --T
s Consensus_1 0 3 + 3 GCT
```

The generated MAF files can be validated using the python 3 porting of `mafValidator` available [here](https://github.com/pangenome/maffer/blob/master/scripts/mafValidator.py). The MAF files have to pass this strict  (and slower for big MAF files) check:

```
python3 mafValidator.py --maf out.maf --validateSequence
```