### PR TITLE
force embedding of paths

### DIFF
--- a/src/smooth.cpp
+++ b/src/smooth.cpp
@@ -1192,6 +1192,23 @@ odgi::graph_t smooth_and_lace(const xg::XG &graph,
         // todo: validate the consensus paths as well
     }
 
+    // embed all paths in the graph
+    smoothed.for_each_path_handle(
+        [&](const path_handle_t& path) {
+            handle_t last;
+            step_handle_t begin_step = smoothed.path_begin(path);
+            smoothed.for_each_step_in_path(
+                path,
+                [&](const step_handle_t &step) {
+                    handle_t h = smoothed.get_handle_of_step(step);
+                    if (step != begin_step) {
+                        smoothed.create_edge(last, h);
+                    }
+                    last = h;
+                });
+        });
+
+
     return smoothed;
 }
 


### PR DESCRIPTION
This avoids the creation of graphs that have paths traversing non-existent edges by adding all edges in every path to the graph.

This isn't the best solution, because we're doing extra work. It might even make sense to remove the other edge additions in the lacing.