### PR TITLE
now the prep.gfa is not removed anymore when specifying -K

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -161,7 +161,7 @@ int main(int argc, char** argv) {
         std::cerr << "[smoothxg::main] building xg index" << std::endl;
         graph.from_gfa(gfa_in_name, args::get(validate),
                        args::get(base).empty() ? gfa_in_name : args::get(base));
-        if (!args::get(keep_temp) && !args::get(no_prep)) {
+        if (!args::get(keep_temp) || !args::get(no_prep)) {
             std::remove(gfa_in_name.c_str());
         }
     }


### PR DESCRIPTION
This should fix #18 