### PR TITLE
Split blocks, trace back ok

### DIFF
--- a/src/blocks.hpp
+++ b/src/blocks.hpp
@@ -35,6 +35,7 @@ struct block_t {
     std::vector<path_range_t> path_ranges;
     bool broken = false;
     bool is_repeat = false;
+    bool is_split = false;
 };
 
 // find the boundaries of blocks that we can compress with spoa

--- a/src/breaks.cpp
+++ b/src/breaks.cpp
@@ -15,135 +15,222 @@ void break_blocks(const xg::XG& graph,
                   const uint64_t& min_autocorr_z,
                   const uint64_t& autocorr_stride,
                   const bool& order_paths_from_longest,
-                  const bool& break_repeats) {
+                  const bool& break_repeats,
+                  const double& min_segment_ratio,
+                  const uint64_t& thread_count) {
 
     const VectorizableHandleGraph& vec_graph = dynamic_cast<const VectorizableHandleGraph&>(graph);
 
-    std::cerr << "[smoothxg::break_blocks] cutting blocks that contain sequences longer than max-poa-length (" << max_poa_length << ")" << std::endl;
+    std::stringstream splits_banner;
+    splits_banner << "[smoothxg::break_blocks] splitting short sequences out of " << blocks.size() << " blocks:";
+    progress_meter::ProgressMeter splits_progress(blocks.size(), splits_banner.str());
 
+    std::atomic<uint64_t> split_blocks;
+    split_blocks.store(0);
+    std::mutex new_blocks_mutex;
+    std::vector<std::pair<double, block_t>> new_blocks;
+    paryfor::parallel_for<uint64_t>(
+        0, blocks.size(), thread_count,
+        [&](uint64_t block_id, int tid) {
+            //for (auto& block : blocks) {
+            auto &block = blocks[block_id];
+            // do we have super-short sequences?
+            double max_seq_length = 0;
+            if (block.path_ranges.size()) {
+                for (auto& path_range : block.path_ranges) {
+                    max_seq_length = std::max(max_seq_length, (double)path_range.length);
+                }
+                bool short_seqs = false;
+                double seq_length_threshold = min_segment_ratio * max_seq_length;
+                for (auto& path_range : block.path_ranges) {
+                    if (path_range.length < seq_length_threshold) {
+                        short_seqs = true; break;
+                    }
+                }
+                if (short_seqs) {
+                    block_t new_block;
+                    // find short path ranges and them to the new block
+                    for (auto& path_range : block.path_ranges) {
+                        if (path_range.length < seq_length_threshold) {
+                            new_block.path_ranges.push_back(path_range);
+                            path_range.length = 0; // signal to clean up
+                        }
+                    }
+                    // remove the path ranges from the old block
+                    block.path_ranges.erase(
+                        std::remove_if(
+                            block.path_ranges.begin(), block.path_ranges.end(),
+                            [](const path_range_t& path_range) {
+                                return path_range.length == 0;
+                            }),
+                        block.path_ranges.end());
+                    for (auto& path_range : block.path_ranges) {
+                        assert(path_range.length > 0);
+                    }
+                    assert(new_block.path_ranges.size());
+                    assert(block.path_ranges.size());
+                    new_block.is_split = true;
+                    ++split_blocks;
+                    for (auto& path_range : new_block.path_ranges) {
+                        new_block.total_path_length += path_range.length;
+                        new_block.max_path_length = std::max(new_block.max_path_length,
+                                                             path_range.length);
+                    }
+                    {
+                        std::lock_guard<std::mutex> guard(new_blocks_mutex);
+                        new_blocks.push_back(std::make_pair(block_id + 0.5, new_block));
+                    }
+                }
+                {
+                    std::lock_guard<std::mutex> guard(new_blocks_mutex);
+                    new_blocks.push_back(std::make_pair(block_id, block));
+                }
+            }
+            splits_progress.increment(1);
+        });
+    splits_progress.finish();
+    std::vector<block_t>().swap(blocks); // clear blocks
+    ips4o::parallel::sort(
+        new_blocks.begin(), new_blocks.end(),
+        [](const std::pair<double, block_t>& a,
+           const std::pair<double, block_t>& b) {
+            return a.first < b.first;
+        });
+    for (auto& p : new_blocks) {
+        blocks.push_back(p.second);
+    }
+    std::vector<std::pair<double, block_t>>().swap(new_blocks); // clear new_blocks
+
+    std::cerr << "[smoothxg::break_blocks] split " << split_blocks << " blocks" << std::endl;
+    std::cerr << "[smoothxg::break_blocks] cutting blocks that contain sequences longer than max-poa-length (" << max_poa_length << ")" << std::endl;
+    
     std::stringstream breaks_banner;
     breaks_banner << "[smoothxg::break_blocks] cutting " << blocks.size() << " blocks:";
     progress_meter::ProgressMeter breaks_progress(blocks.size(), breaks_banner.str());
-
+    
     uint64_t n_cut_blocks = 0;
     uint64_t n_repeat_blocks = 0;
-    for (auto& block : blocks) {
-        // check if we have sequences that are too long
-        bool to_break = false;
-        for (auto& path_range : block.path_ranges) {
-            if (path_range.length > max_poa_length) {
-                to_break = true;
-                break;
-            }
-        }
-        if (!to_break) continue; // skip if we're spoa-able
-        ++n_cut_blocks;
-        uint64_t cut_length = max_poa_length;
-        bool found_repeat = false;
-        // otherwise let's see if we've got repeats that we can use to chop things up
-        // find if there is a repeat
-        if (break_repeats) {
-            std::vector<sautocorr::repeat_t> repeats;
+    paryfor::parallel_for<uint64_t>(
+        0, blocks.size(), thread_count,
+        [&](uint64_t block_id, int tid) {
+            auto &block = blocks[block_id];
+            // check if we have sequences that are too long
+            bool to_break = false;
             for (auto& path_range : block.path_ranges) {
-                // steps in id space
-                std::string seq;
-                std::string name = graph.get_path_name(graph.get_path_handle_of_step(path_range.begin));
-                for (step_handle_t step = path_range.begin;
-                     step != path_range.end;
-                     step = graph.get_next_step(step)) {
-                    seq.append(graph.get_sequence(graph.get_handle_of_step(step)));
-                }
-                if (seq.length() < 2*min_copy_length) continue;
-                //std::cerr << "on " << name << "\t" << seq.length() << std::endl;
-                std::vector<uint8_t> vec(seq.begin(), seq.end());
-                sautocorr::repeat_t result = sautocorr::repeat(vec,
-                                                               min_copy_length,
-                                                               max_copy_length,
-                                                               min_copy_length,
-                                                               min_autocorr_z,
-                                                               autocorr_stride);
-                repeats.push_back(result);
-            }
-            // if there is, set the cut length to some fraction of it
-            std::vector<double> lengths;
-            double max_z = 0;
-            for (auto& repeat : repeats) {
-                if (repeat.length > 0) {
-                    lengths.push_back(repeat.length);
-                    max_z = std::max(repeat.z_score, max_z);
+                if (path_range.length > max_poa_length) {
+                    to_break = true;
+                    break;
                 }
             }
-            found_repeat = !lengths.empty();
-            if (found_repeat) {
-                double repeat_length = sautocorr::vec_mean(lengths.begin(), lengths.end());
-                cut_length = std::round(repeat_length / 2.0);
-                ++n_repeat_blocks;
-                //std::cerr << "found repeat of " << repeat_length << " and Z-score " << max_z << " cutting to " << cut_length << std::endl;
-            } else {
-                // if not, chop blindly
-                cut_length = max_poa_length;
-            }
-        }
-        std::vector<path_range_t> chopped_ranges;
-        for (auto& path_range : block.path_ranges) {
-
-            if (!found_repeat && path_range.length < cut_length) {
-                chopped_ranges.push_back(path_range);
-                continue;
-            }
-            // now find outlier clusters based on stdev and mean
-            // extract a minimum viable repeat length
-            // scan across the step vector, looking for where the repeat region begins and ends
-            // cut at the repeat boundaries
-
-            // Q: should we determine the repeat length for each sequence or all?
-            // each is simple, but maybe expensive
-            // all could provide higher precision, but it's muddier
-
-            // if this doesn't work, we're going to blindly cut anyway
-            uint64_t last_cut = 0;
-            step_handle_t last_end = path_range.begin;
-            //path_range_t* new_range = nullptr;
-            uint64_t pos = 0;
-            step_handle_t step;
-            for (step = path_range.begin;
-                 step != path_range.end;
-                 step = graph.get_next_step(step)) {
-                //handle_t h = graph.get_handle_of_step(step);
-                //uint64_t id = graph.get_id(h);
-                //int64_t node_pos = vec_graph.node_vector_offset(id);
-                pos += graph.get_length(graph.get_handle_of_step(step));
-                if (pos - last_cut > cut_length) {
-                    step_handle_t next = graph.get_next_step(step);
-                    chopped_ranges.push_back({last_end, next, pos - last_cut});
-                    last_end = next;
-                    last_cut = pos;
+            if (to_break) {
+                ++n_cut_blocks;
+                uint64_t cut_length = max_poa_length;
+                bool found_repeat = false;
+                // otherwise let's see if we've got repeats that we can use to chop things up
+                // find if there is a repeat
+                if (break_repeats) {
+                    std::vector<sautocorr::repeat_t> repeats;
+                    for (auto& path_range : block.path_ranges) {
+                        // steps in id space
+                        std::string seq;
+                        std::string name = graph.get_path_name(graph.get_path_handle_of_step(path_range.begin));
+                        for (step_handle_t step = path_range.begin;
+                             step != path_range.end;
+                             step = graph.get_next_step(step)) {
+                            seq.append(graph.get_sequence(graph.get_handle_of_step(step)));
+                        }
+                        if (seq.length() < 2*min_copy_length) continue;
+                        //std::cerr << "on " << name << "\t" << seq.length() << std::endl;
+                        std::vector<uint8_t> vec(seq.begin(), seq.end());
+                        sautocorr::repeat_t result = sautocorr::repeat(vec,
+                                                                       min_copy_length,
+                                                                       max_copy_length,
+                                                                       min_copy_length,
+                                                                       min_autocorr_z,
+                                                                       autocorr_stride);
+                        repeats.push_back(result);
+                    }
+                    // if there is, set the cut length to some fraction of it
+                    std::vector<double> lengths;
+                    double max_z = 0;
+                    for (auto& repeat : repeats) {
+                        if (repeat.length > 0) {
+                            lengths.push_back(repeat.length);
+                            max_z = std::max(repeat.z_score, max_z);
+                        }
+                    }
+                    found_repeat = !lengths.empty();
+                    if (found_repeat) {
+                        double repeat_length = sautocorr::vec_mean(lengths.begin(), lengths.end());
+                        cut_length = std::round(repeat_length / 2.0);
+                        ++n_repeat_blocks;
+                        //std::cerr << "found repeat of " << repeat_length << " and Z-score " << max_z << " cutting to " << cut_length << std::endl;
+                    } else {
+                        // if not, chop blindly
+                        cut_length = max_poa_length;
+                    }
                 }
+                std::vector<path_range_t> chopped_ranges;
+                for (auto& path_range : block.path_ranges) {
+
+                    if (!found_repeat && path_range.length < cut_length) {
+                        chopped_ranges.push_back(path_range);
+                        continue;
+                    }
+                    // now find outlier clusters based on stdev and mean
+                    // extract a minimum viable repeat length
+                    // scan across the step vector, looking for where the repeat region begins and ends
+                    // cut at the repeat boundaries
+
+                    // Q: should we determine the repeat length for each sequence or all?
+                    // each is simple, but maybe expensive
+                    // all could provide higher precision, but it's muddier
+
+                    // if this doesn't work, we're going to blindly cut anyway
+                    uint64_t last_cut = 0;
+                    step_handle_t last_end = path_range.begin;
+                    //path_range_t* new_range = nullptr;
+                    uint64_t pos = 0;
+                    step_handle_t step;
+                    for (step = path_range.begin;
+                         step != path_range.end;
+                         step = graph.get_next_step(step)) {
+                        //handle_t h = graph.get_handle_of_step(step);
+                        //uint64_t id = graph.get_id(h);
+                        //int64_t node_pos = vec_graph.node_vector_offset(id);
+                        pos += graph.get_length(graph.get_handle_of_step(step));
+                        if (pos - last_cut > cut_length) {
+                            step_handle_t next = graph.get_next_step(step);
+                            chopped_ranges.push_back({last_end, next, pos - last_cut});
+                            last_end = next;
+                            last_cut = pos;
+                        }
+                    }
+                    if (step != last_end) {
+                        chopped_ranges.push_back({last_end, step, pos - last_cut});
+                    }
+                }
+                block.path_ranges = chopped_ranges;
+                // order the path ranges from longest/shortest to shortest/longest
+                ips4o::parallel::sort(
+                    block.path_ranges.begin(), block.path_ranges.end(),
+                    order_paths_from_longest
+                    ?
+                    [](const path_range_t& a,
+                       const path_range_t& b) {
+                        return a.length > b.length;
+                    }
+                    :
+                    [](const path_range_t& a,
+                       const path_range_t& b) {
+                        return a.length < b.length;
+                    }
+                    );
+                block.broken = true;
+                block.is_repeat = found_repeat;
+                breaks_progress.increment(1);
             }
-            if (step != last_end) {
-                chopped_ranges.push_back({last_end, step, pos - last_cut});
-            }
-        }
-        block.path_ranges = chopped_ranges;
-        // order the path ranges from longest/shortest to shortest/longest
-        ips4o::parallel::sort(
-            block.path_ranges.begin(), block.path_ranges.end(),
-            order_paths_from_longest
-            ?
-            [](const path_range_t& a,
-               const path_range_t& b) {
-                return a.length > b.length;
-            }
-            :
-            [](const path_range_t& a,
-               const path_range_t& b) {
-                return a.length < b.length;
-            }
-        );
-        block.broken = true;
-        block.is_repeat = found_repeat;
-        breaks_progress.increment(1);
-    }
+        });
     breaks_progress.finish();
     std::cerr << "[smoothxg::break_blocks] cut " << n_cut_blocks << " blocks of which " << n_repeat_blocks << " had repeats" << std::endl;
 }

--- a/src/breaks.hpp
+++ b/src/breaks.hpp
@@ -12,6 +12,7 @@
 #include "blocks.hpp"
 #include "sautocorr.hpp"
 #include "xg.hpp"
+#include "paryfor.hpp"
 
 namespace smoothxg {
 
@@ -27,6 +28,8 @@ void break_blocks(const xg::XG& graph,
                   const uint64_t& min_autocorr_z,
                   const uint64_t& autocorr_stride,
                   const bool& order_paths_from_longest,
-                  const bool& break_repeats);
+                  const bool& break_repeats,
+                  const double& min_segment_ratio,
+                  const uint64_t& thread_count);
 
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -39,6 +39,7 @@ int main(int argc, char** argv) {
     args::ValueFlag<uint64_t> _max_block_jump(parser, "N", "maximum path jump to include in block [default: 5000]", {'j', "max-path-jump"});
     args::ValueFlag<uint64_t> _min_subpath(parser, "N", "minimum length of a subpath to include in partial order alignment [default: 0 / no filter]", {'k', "min-subpath"});
     args::ValueFlag<uint64_t> _max_edge_jump(parser, "N", "maximum edge jump before breaking [default: 5000]", {'e', "max-edge-jump"});
+    args::ValueFlag<double> _min_segment_ratio(parser, "N", "split out segments in a block that are less than this fraction of the length of the longest path range in the block [default: 0.05]", {'R', "min-segment-ratio"});
     args::ValueFlag<uint64_t> _min_copy_length(parser, "N", "minimum repeat length to collapse [default: 1000]", {'c', "min-copy-length"});
     args::ValueFlag<uint64_t> _max_copy_length(parser, "N", "maximum repeat length to attempt to detect [default: 20000]", {'W', "max-copy-length"});
     args::ValueFlag<uint64_t> _max_poa_length(parser, "N", "maximum sequence length to put into poa [default: 10000]", {'l', "max-poa-length"});
@@ -77,6 +78,7 @@ int main(int argc, char** argv) {
     if (n_threads) {
         omp_set_num_threads(args::get(num_threads));
     } else {
+        n_threads = 1;
         omp_set_num_threads(1);
     }
 
@@ -87,6 +89,7 @@ int main(int argc, char** argv) {
     uint64_t min_copy_length = _min_copy_length ? args::get(_min_copy_length) : 1000;
     uint64_t max_copy_length = _max_copy_length ? args::get(_max_copy_length) : 20000;
     uint64_t max_poa_length = _max_poa_length ? args::get(_max_poa_length) : 10000;
+    double min_segment_ratio = _min_segment_ratio ? args::get(_min_segment_ratio) : 0.05;
 
     if (!args::get(use_spoa) && args::get(change_alignment_mode)) {
         std::cerr
@@ -183,7 +186,9 @@ int main(int argc, char** argv) {
                            min_autocorr_z,
                            autocorr_stride,
                            order_paths_from_longest,
-                           true); // break repeats
+                           true,
+                           min_segment_ratio,
+                           n_threads);
 
     bool local_alignment = args::get(use_spoa) ^ args::get(change_alignment_mode);
 

--- a/src/smooth.cpp
+++ b/src/smooth.cpp
@@ -117,7 +117,7 @@ odgi::graph_t smooth_abpoa(const xg::XG &graph, const block_t &block, const uint
     abpt->out_gfa = 1; // must be set to get the graph
     abpt->out_msa = maf != nullptr ? 1 : 0; // must be set when we extract the MSA
     abpt->out_cons = generate_consensus;
-    abpt->amb_strand = 1;
+    abpt->amb_strand = 1; // we'll align both ways and check which is better
     abpt->match = poa_m;
     abpt->mismatch = poa_n;
     abpt->gap_open1 = poa_g;
@@ -160,18 +160,51 @@ odgi::graph_t smooth_abpoa(const xg::XG &graph, const block_t &block, const uint
         res.graph_cigar = 0, res.n_cigar = 0, res.is_rc = 0;
         abpt->rev_cigar = 0;
         abpoa_align_sequence_to_graph(ab, abpt, bseqs[i], seq_lens[i], &res);
-        abpoa_add_graph_alignment(ab, abpt, bseqs[i], seq_lens[i], res, i,
-                                  n_seqs);
-        is_rc[i] = res.is_rc;
-        if (res.is_rc) {
-            aln_is_reverse.push_back(true);
-            //std::cerr << "is_rc" << std::endl;
+        if (res.traceback_ok) {
+            abpoa_add_graph_alignment(ab, abpt, bseqs[i], seq_lens[i], res, i,
+                                      n_seqs);
+            is_rc[i] = res.is_rc;
+            if (res.is_rc) {
+                aln_is_reverse.push_back(true);
+                //std::cerr << "is_rc" << std::endl;
+            } else {
+                aln_is_reverse.push_back(false);
+                // std::cerr << "is_rc_not" << std::endl;
+            }
+            if (res.n_cigar) {
+                free(res.graph_cigar);
+            }
         } else {
-            aln_is_reverse.push_back(false);
-            // std::cerr << "is_rc_not" << std::endl;
-        }
-        if (res.n_cigar) {
-            free(res.graph_cigar);
+            // the alignment traceback failed
+            if (!banded_alignment) {
+                // we bail if we are already running without banding
+                std::string s = "smoothxg_failed_block_" + std::to_string(block_id) + ".fa";
+                std::cerr << "[smoothxg] error! failure in alignment in non-banded mode, "
+                          << "writing failed block to " << s << std::endl;
+                std::ofstream fasta(s.c_str());
+                for (uint64_t i = 0; i < seqs.size(); ++i) {
+                    fasta << ">" << names[i] << " " << seqs[i].size() << std::endl
+                          << seqs[i] << std::endl;
+                }
+                fasta.close();
+                exit(1);
+            } else {
+                // otherwise, we will try to align this without banding
+                // first cleaning up
+                for (i = 0; i < n_seqs; ++i) {
+                    free(bseqs[i]);
+                }
+                free(bseqs);
+                free(seq_lens);
+                abpoa_free(ab, abpt);
+                abpoa_free_para(abpt);
+                // then running non-banded abPOA
+                return smooth_abpoa(graph, block, block_id,
+                                    poa_m, poa_n, poa_g,
+                                    poa_e, poa_q, poa_c,
+                                    local_alignment, false,
+                                    consensus_name);
+            }
         }
     }
 

--- a/src/smooth.cpp
+++ b/src/smooth.cpp
@@ -15,7 +15,7 @@ KDQ_INIT(int)
 #define kdq_int_t kdq_t(int)
 
 // to write each block to a FASTA and TSV
-//#define SMOOTH_WRITE_BLOCKS_FASTA true
+#define SMOOTH_WRITE_BLOCKS_FASTA true
 
 static inline int ilog2_64(abpoa_para_t *abpt, uint64_t v) {
     uint64_t t, tt;

--- a/src/smooth.hpp
+++ b/src/smooth.hpp
@@ -37,7 +37,7 @@ odgi::graph_t smooth_abpoa(const xg::XG &graph, const block_t &block, const uint
                            int poa_e, int poa_q, int poa_c,
                            bool local_alignment,
                            std::string *maf,
-                           bool banded_alignment = true,
+                           bool banded_alignment,
                            const std::string &consensus_name = "");
 
 odgi::graph_t smooth_spoa(const xg::XG &graph, const block_t &block,


### PR DESCRIPTION
This PR does several things.

First, it lets us split blocks into "big" sequences and "shorter" sequences less than some threshold of the maximum sequence length. This can avoid the occasional problem of aligning a really short sequence into a long POA. The set of short sequences are all still aligned to each other in another (subsequently placed) block.

It also adjusts the abPOA implementation to not break when our traceback fails, but rather to return a flag that we can handle. It's currently not handled, which could be dangerous :boom: . But, testing hasn't shown any issues yet.