### PR TITLE
merge more MAF blocks and consensus sequences

### DIFF
--- a/src/smooth.cpp
+++ b/src/smooth.cpp
@@ -588,8 +588,8 @@ odgi::graph_t smooth_and_lace(const xg::XG &graph,
                             if (merged_maf_blocks.field_blocks.empty()){
                                 merged = true;
                             } else {
-                                // The merged group has to have the number of rows (then paths in this case) as the block to merge
-                                if (merged_maf_blocks.rows.size() + (add_consensus ? 1 : 0) == num_seq_in_block) {
+                                // The block to merge must have no new paths respect to the merged group
+                                if (merged_maf_blocks.rows.size() >= num_seq_in_block - (add_consensus ? 1 : 0) ) {
                                     merged = true;
 
                                     for (uint64_t i = 0; i < num_seq_in_block; i++) {
@@ -648,6 +648,19 @@ odgi::graph_t smooth_and_lace(const xg::XG &graph,
                                                     maf_row.aligned_seq
                                             }
                                     ));
+                                }
+                            }
+
+                            // Put gaps for paths not present in the last merged block (block_id) respect to the merged group
+                            if (merged_maf_blocks.rows.size() > num_seq_in_block - (add_consensus ? 1 : 0) ) {
+                                // I take the merged group length from a one of the path present in the merged group and in the last merged block
+                                uint64_t length_to_reach = merged_maf_blocks.rows[mafs[block_id][0].path_name].aligned_seq.length();
+
+                                for (auto & row : merged_maf_blocks.rows){
+                                    if (row.second.aligned_seq.length() < length_to_reach){
+                                        uint64_t num_gaps_to_add = length_to_reach - row.second.aligned_seq.length();
+                                        for (uint64_t  i = 0; i < num_gaps_to_add; i++){ row.second.aligned_seq += "-"; }
+                                    }
                                 }
                             }
                         }

--- a/src/smooth.cpp
+++ b/src/smooth.cpp
@@ -589,34 +589,33 @@ odgi::graph_t smooth_and_lace(const xg::XG &graph,
                                 merged = true;
                             } else {
                                 // The block to merge must have no new paths respect to the merged group
-                                if (merged_maf_blocks.rows.size() >= num_seq_in_block - (add_consensus ? 1 : 0) ) {
-                                    merged = true;
+                                merged = true;
 
-                                    for (uint64_t i = 0; i < num_seq_in_block; i++) {
-                                        // Do not check the consensus (always forward)
-                                        if (!add_consensus || i < num_seq_in_block - 1) {
-                                            auto maf_row = mafs[block_id][i];
+                                for (uint64_t i = 0; i < num_seq_in_block; i++) {
+                                    // Do not check the consensus (always forward)
+                                    if (!add_consensus || i < num_seq_in_block - 1) {
+                                        auto maf_row = mafs[block_id][i];
 
-                                            if (merged_maf_blocks.rows.count(maf_row.path_name) != 1){
-                                                merged = false; // Current block not mergeable, so write the blocks which are waiting in memory
-                                                prep_new_merge_group = !is_last_block;
-                                                break;
-                                            }
+                                        if (merged_maf_blocks.rows.count(maf_row.path_name) != 1){
+                                            merged = false; // Current block not mergeable, so write the blocks which are waiting in memory
+                                            prep_new_merge_group = !is_last_block;
+                                            break;
+                                        }
 
-                                            maf_partial_row_t merged_maf_row = merged_maf_blocks.rows[maf_row.path_name];
+                                        maf_partial_row_t merged_maf_row = merged_maf_blocks.rows[maf_row.path_name];
 
-                                            if (
-                                                    (merged_maf_row.is_reversed != maf_row.is_reversed) ||
-                                                    (merged_maf_row.is_reversed && ((merged_maf_row.record_start - maf_row.seq_size) != maf_row.record_start)) ||
-                                                    (!merged_maf_row.is_reversed && ((merged_maf_row.record_start + merged_maf_row.seq_size) != maf_row.record_start))
-                                                    ) {
-                                                merged = false; // Current block not mergeable, so write the blocks which are waiting in memory
-                                                prep_new_merge_group = !is_last_block;
-                                                break;
-                                            }
+                                        if (
+                                                (merged_maf_row.is_reversed != maf_row.is_reversed) ||
+                                                (merged_maf_row.is_reversed && ((merged_maf_row.record_start - maf_row.seq_size) != maf_row.record_start)) ||
+                                                (!merged_maf_row.is_reversed && ((merged_maf_row.record_start + merged_maf_row.seq_size) != maf_row.record_start))
+                                                ) {
+                                            merged = false; // Current block not mergeable, so write the blocks which are waiting in memory
+                                            prep_new_merge_group = !is_last_block;
+                                            break;
                                         }
                                     }
                                 }
+
                             }
                         }
                     }

--- a/src/smooth.cpp
+++ b/src/smooth.cpp
@@ -501,9 +501,12 @@ void _put_block_in_group(
             if (merged_maf_blocks.rows.count(maf_row.path_name) == 1){
                 if (maf_row.is_reversed){
                     merged_maf_blocks.rows[maf_row.path_name].record_start -= maf_row.seq_size;
+
+                    merged_maf_blocks.rows[maf_row.path_name].aligned_seq = maf_row.aligned_seq + merged_maf_blocks.rows[maf_row.path_name].aligned_seq;
+                }else{
+                    merged_maf_blocks.rows[maf_row.path_name].aligned_seq += maf_row.aligned_seq;
                 }
                 merged_maf_blocks.rows[maf_row.path_name].seq_size += maf_row.seq_size;
-                merged_maf_blocks.rows[maf_row.path_name].aligned_seq += maf_row.aligned_seq;
             }else{
                 merged_maf_blocks.rows.insert(std::pair<std::string, maf_partial_row_t>(
                         maf_row.path_name,

--- a/src/smooth.cpp
+++ b/src/smooth.cpp
@@ -1132,13 +1132,18 @@ odgi::graph_t smooth_and_lace(const xg::XG &graph,
                   << std::endl;
 
         // consensus path and connections
-        ips4o::parallel::sort(
+        /*ips4o::parallel::sort(
             consensus_mapping.begin(), consensus_mapping.end(),
             [](const path_position_range_t &a, const path_position_range_t &b) {
                 auto &a_id = as_integer(a.base_path);
                 auto &b_id = as_integer(b.base_path);
                 return (a_id < b_id || a_id == b_id && a.start_pos < b.start_pos);
-            });
+            });*/
+        // Sort respect to the block_id, to avoid re-sorting to embed the merged consensus paths
+        ips4o::parallel::sort(consensus_mapping.begin(), consensus_mapping.end(),
+                              [](const path_position_range_t &a, const path_position_range_t &b) {
+                                  return (a.target_graph_id < b.target_graph_id);
+                              });
 
         // by definition, the consensus paths are embedded in our blocks, which
         // simplifies things we'll still need to add a new path for each consensus
@@ -1167,10 +1172,11 @@ odgi::graph_t smooth_and_lace(const xg::XG &graph,
 
         // Sort respect to the target_graph_id (== block_id), because in the merged_block_id_intervals
         // there are the block_id_intervals expressed as first_block_id and last_block_id
-        ips4o::parallel::sort(consensus_mapping.begin(), consensus_mapping.end(),
+        // No longer necessary, if the first sort is confirmed.
+        /*ips4o::parallel::sort(consensus_mapping.begin(), consensus_mapping.end(),
                               [](const path_position_range_t &a, const path_position_range_t &b) {
                                   return (a.target_graph_id < b.target_graph_id);
-                              });
+                              });*/
         for (auto& merged_block_id_interval : merged_block_id_intervals){
             path_handle_t consensus_path = smoothed.create_path_handle(
                     consensus_base_name +

--- a/src/smooth.cpp
+++ b/src/smooth.cpp
@@ -535,15 +535,15 @@ void _put_block_in_group(
             ));
         }
     }
-    
+
     // Put gaps for paths not present in the last merged block (block_id) respect to the merged group
     if (merged_maf_blocks.rows.size() > num_seq_in_block - (add_consensus ? 1 : 0) ) {
         // I take the merged group length from a one of the path present in the merged group and in the last merged block
-        uint64_t length_to_reach = merged_maf_blocks.rows[mafs[block_id][0].path_name].aligned_seq.length();
+        alignment_size_merged_maf_blocks = merged_maf_blocks.rows[mafs[block_id][0].path_name].aligned_seq.length();
 
         for (auto & row : merged_maf_blocks.rows){
-            if (row.second.aligned_seq.length() < length_to_reach){
-                uint64_t num_gaps_to_add = length_to_reach - row.second.aligned_seq.length();
+            if (row.second.aligned_seq.length() < alignment_size_merged_maf_blocks){
+                uint64_t num_gaps_to_add = alignment_size_merged_maf_blocks - row.second.aligned_seq.length();
                 for (uint64_t  i = 0; i < num_gaps_to_add; i++){ row.second.aligned_seq += "-"; }
             }
         }
@@ -581,7 +581,6 @@ odgi::graph_t smooth_and_lace(const xg::XG &graph,
         if (produce_maf || (add_consensus && merge_blocks)){
             uint64_t block_id = 0;
 
-            uint64_t alignment_size_merged_maf_blocks = 0;
             maf_t merged_maf_blocks;
 
             uint64_t num_block = blocks.size();
@@ -724,7 +723,7 @@ odgi::graph_t smooth_and_lace(const xg::XG &graph,
 
                                         start_cons_pos_in_alignment += maf_cons_row.second.aligned_seq.length();
 
-
+                                        // Manage merged consensus sequence
                                         if (merged_maf_blocks_size > 1) {
                                             merged_consensus_seq_size += maf_cons_row.second.seq_size;
                                             merged_consensus_path_length += maf_cons_row.second.path_length;
@@ -758,8 +757,6 @@ odgi::graph_t smooth_and_lace(const xg::XG &graph,
                             }
 
                             clear_string(block_id_range);
-
-                            alignment_size_merged_maf_blocks = 0;
 
                             clear_vector(merged_maf_blocks.field_blocks);
                             for (auto& maf_row : merged_maf_blocks.rows){


### PR DESCRIPTION
This relaxes the constraints to merge the MAF blocks and the consensus sequences embedded in the smoothed graph, leading to bigger merged groups. The consensus graph generation in #32 could take advantage of longer consensus sequences.

**Before**
```
##maf version=1
# smoothxg
# input=xxx.gfa sequences=2
# POA=abPOA alignment_mode=global order_paths=from_shortest
# max_block_weight=10 max_block_jump=5000 min_subpath=0 max_edge_jump=5000
# max_poa_length=10000 min_copy_length=1000 max_copy_length=20000 min_autocorr_z=5 autocorr_stride=50

a blocks=0-4 loops=false merged=true
s x              0 47 + 58 CAAATAAGGCTCTTGGAAATTTTCTGGAGATTACAATATGCATCTCA
s y              0 44 + 44 CAAATAAGGCTC---GAAATTTTCTGGAGATTACAATATGCATCTCA
s Consensus_0    0 12 + 12 CAAATAAGGCTC-----------------------------------
s Consensus_1    0  4 +  4 ------------TTGG-------------------------------
s Consensus_2    0 12 + 12 ----------------AAATTTTCTGGA-------------------
s Consensus_3    0  7 +  7 ----------------------------GATTACA------------
s Consensus_4    0 12 + 12 -----------------------------------ATATGCATCTCA
s Consensus_0-4  0 47 + 47 CAAATAAGGCTCTTGGAAATTTTCTGGAGATTACAATATGCATCTCA

a blocks=5 loops=false
s x           47 11 + 58 CCAACTCTCTG
s Consensus_5  0 11 + 11 CCAACTCTCTG
```

**Now**
```
##maf version=1
# smoothxg
# input=xxx.gfa sequences=2
# POA=abPOA alignment_mode=global order_paths=from_shortest
# max_block_weight=10 max_block_jump=5000 min_subpath=0 max_edge_jump=5000
# max_poa_length=10000 min_copy_length=1000 max_copy_length=20000 min_autocorr_z=5 autocorr_stride=50

a blocks=0-5 loops=false merged=true
s x              0 58 + 58 CAAATAAGGCTCTTGGAAATTTTCTGGAGATTACAATATGCATCTCACCAACTCTCTG
s y              0 44 + 44 CAAATAAGGCTC---GAAATTTTCTGGAGATTACAATATGCATCTCA-----------
s Consensus_0    0 12 + 12 CAAATAAGGCTC----------------------------------------------
s Consensus_1    0  4 +  4 ------------TTGG------------------------------------------
s Consensus_2    0 12 + 12 ----------------AAATTTTCTGGA------------------------------
s Consensus_3    0  7 +  7 ----------------------------GATTACA-----------------------
s Consensus_4    0 12 + 12 -----------------------------------ATATGCATCTCA-----------
s Consensus_5    0 11 + 11 -----------------------------------------------CCAACTCTCTG
s Consensus_0-5  0 58 + 58 CAAATAAGGCTCTTGGAAATTTTCTGGAGATTACAATATGCATCTCACCAACTCTCTG
```