### PR TITLE
better control over the merge behavior of MAF blocks and consensus sequences

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -226,6 +226,11 @@ int main(int argc, char** argv) {
         maf_header += "# smoothxg\n";
         maf_header += "# input=" + filename + " sequences=" + std::to_string(graph.get_path_count()) + "\n";
 
+        // Merge mode
+        maf_header += "# merge_blocks=";
+        maf_header += (args::get(merge_blocks) ? "true" : "false");
+        maf_header += " min_fraction_contiguous_paths=" + std::to_string(min_fraction_contiguous_paths) + "\n";
+
         // POA
         maf_header += "# POA=";
         maf_header += (args::get(use_spoa) ? "SPOA" : "abPOA");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -95,7 +95,7 @@ int main(int argc, char** argv) {
         omp_set_num_threads(1);
     }
 
-    double min_fraction_contiguous_paths = _min_fraction_contiguous_paths ? max(min(args::get(_min_fraction_contiguous_paths), 1.0), 0.01) : 1.0;
+    double min_fraction_contiguous_paths = _min_fraction_contiguous_paths ? min(args::get(_min_fraction_contiguous_paths), 1.0) : 1.0;
 
     uint64_t max_block_weight = _max_block_weight ? args::get(_max_block_weight) : 10000;
     uint64_t max_block_jump = _max_block_jump ? args::get(_max_block_jump) : 5000;
@@ -259,7 +259,7 @@ int main(int argc, char** argv) {
                                               poa_c,
                                               local_alignment,
                                               args::get(write_msa_in_maf_format), maf_header,
-                                              args::get(merge_blocks), _min_fraction_contiguous_paths,
+                                              args::get(merge_blocks), min_fraction_contiguous_paths,
                                               !args::get(use_spoa),
                                               args::get(add_consensus) ? "Consensus_" : "");
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,7 +33,7 @@ int main(int argc, char** argv) {
     args::ValueFlag<std::string> write_msa_in_maf_format(parser, "FILE","write the multiple sequence alignments (MSAs) in MAF format in this file",{'m', "write-msa-in-maf-format"});
     args::Flag add_consensus(parser, "bool", "include consensus sequence in the smoothed graph", {'a', "add-consensus"});
     args::Flag merge_blocks(parser, "bool","merge contiguous MAF blocks in the MAF output and consensus sequences in the smoothed graph",{'M', "merge-blocks"});
-    args::ValueFlag<double> _min_fraction_contiguous_paths(parser, "bool","minimum fraction of paths that have to be contiguous for merging MAF blocks and consensus sequences (default: 1.0)",{'F', "min-fraction-contiguous-paths"});
+    args::ValueFlag<double> _contiguous_path_jaccard(parser, "bool","minimum fraction of paths that have to be contiguous for merging MAF blocks and consensus sequences (default: 1.0)",{'J', "contiguous-path-jaccard"});
 
     args::ValueFlag<std::string> base(parser, "BASE", "use this basename for temporary files during build", {'b', "base"});
     args::Flag no_prep(parser, "bool", "do not prepare the graph for processing (prep is equivalent to odgi chop followed by odgi sort -p sYgs, and is disabled when taking XG input)", {'n', "no-prep"});
@@ -76,9 +76,9 @@ int main(int argc, char** argv) {
         return 1;
     }
 
-    if (!args::get(merge_blocks) && _min_fraction_contiguous_paths) {
+    if (!args::get(merge_blocks) && _contiguous_path_jaccard) {
         std::cerr << "[smoothxg::main] error: Please specify -M/--merge-blocks option to use the "
-                     "-F/--min-fraction-contiguous-paths option." << std::endl;
+                     "-J/--contiguous-path-jaccard option." << std::endl;
         return 1;
     }
 
@@ -95,7 +95,7 @@ int main(int argc, char** argv) {
         omp_set_num_threads(1);
     }
 
-    double min_fraction_contiguous_paths = _min_fraction_contiguous_paths ? min(args::get(_min_fraction_contiguous_paths), 1.0) : 1.0;
+    double contiguous_path_jaccard = _contiguous_path_jaccard ? min(args::get(_contiguous_path_jaccard), 1.0) : 1.0;
 
     uint64_t max_block_weight = _max_block_weight ? args::get(_max_block_weight) : 10000;
     uint64_t max_block_jump = _max_block_jump ? args::get(_max_block_jump) : 5000;
@@ -229,7 +229,7 @@ int main(int argc, char** argv) {
         // Merge mode
         maf_header += "# merge_blocks=";
         maf_header += (args::get(merge_blocks) ? "true" : "false");
-        maf_header += " min_fraction_contiguous_paths=" + std::to_string(min_fraction_contiguous_paths) + "\n";
+        maf_header += " contiguous_path_jaccard=" + std::to_string(contiguous_path_jaccard) + "\n";
 
         // POA
         maf_header += "# POA=";
@@ -264,7 +264,7 @@ int main(int argc, char** argv) {
                                               poa_c,
                                               local_alignment,
                                               args::get(write_msa_in_maf_format), maf_header,
-                                              args::get(merge_blocks), min_fraction_contiguous_paths,
+                                              args::get(merge_blocks), contiguous_path_jaccard,
                                               !args::get(use_spoa),
                                               args::get(add_consensus) ? "Consensus_" : "");
 

--- a/src/smooth.cpp
+++ b/src/smooth.cpp
@@ -576,7 +576,8 @@ odgi::graph_t smooth_and_lace(const xg::XG &graph,
                               int poa_g, int poa_e,
                               int poa_q, int poa_c,
                               bool local_alignment,
-                              std::string &path_output_maf, std::string &maf_header, bool merge_blocks,
+                              std::string &path_output_maf, std::string &maf_header,
+                              bool merge_blocks, double min_fraction_contiguous_paths,
                               bool use_abpoa,
                               const std::string &consensus_base_name) {
 

--- a/src/smooth.cpp
+++ b/src/smooth.cpp
@@ -667,18 +667,22 @@ odgi::graph_t smooth_and_lace(const xg::XG &graph,
                                     }
                                 }
 
-                                double fraction_contiguous_path = (double) num_contiguous_seq / (double)(num_seq_in_block - (add_consensus ? 1 : 0));
+                                if (merged){
+                                    double fraction_contiguous_path = (double) num_contiguous_seq /
+                                            (double)(num_seq_in_block - (add_consensus ? 1 : 0) + merged_maf_blocks.rows.size() - num_contiguous_seq);
 
-                                /*std::cerr << "block_id: " << block_id << std::endl;
-                                std::cerr << "\tnum_contiguous_seq: " << num_contiguous_seq << std::endl;
-                                std::cerr << "\tdenominator: " << (num_seq_in_block - (add_consensus ? 1 : 0)) << std::endl;
-                                std::cerr << "\tfraction_contiguous_path: " << fraction_contiguous_path << std::endl;
-                                std::cerr << "\tmerged: " << merged << std::endl;
-                                std::cerr << "\tfraction_contiguous_path >= min_fraction_contiguous_paths: " <<
-                                    (fraction_contiguous_path >= min_fraction_contiguous_paths) << std::endl << std::endl;*/
+                                    /*std::cerr << "block_id: " << block_id << std::endl;
+                                    std::cerr << "\tnum_contiguous_seq: " << num_contiguous_seq << std::endl;
+                                    std::cerr << "\tdenominator: " <<
+                                        (double)(num_seq_in_block - (add_consensus ? 1 : 0) + merged_maf_blocks.rows.size() - num_contiguous_seq) << std::endl;
+                                    std::cerr << "\tfraction_contiguous_path: " << fraction_contiguous_path << std::endl;
+                                    std::cerr << "\tmerged: " << merged << std::endl;
+                                    std::cerr << "\tfraction_contiguous_path >= min_fraction_contiguous_paths: " <<
+                                        (fraction_contiguous_path >= min_fraction_contiguous_paths) << std::endl << std::endl;*/
 
-                                if (merged && fraction_contiguous_path < min_fraction_contiguous_paths){
-                                    merged = false;
+                                    if (fraction_contiguous_path < min_fraction_contiguous_paths){
+                                        merged = false;
+                                    }
                                 }
                             }
                         }
@@ -816,7 +820,12 @@ odgi::graph_t smooth_and_lace(const xg::XG &graph,
 
                         if (!merged && !prep_new_merge_group) {
                             if (produce_maf){
-                                out_maf << "a blocks=" + std::to_string(block_id) << " loops=" << (contains_loops ? "true" : "false") << std::endl;
+                                out_maf << "a blocks=" + std::to_string(block_id) << " loops=" << (contains_loops ? "true" : "false");
+                                if (fraction_below_threshold) {
+                                    out_maf << " below_thresh=true";
+                                }
+
+                                out_maf << std::endl;
                                 write_maf_rows(out_maf, mafs[block_id]);
                             }
 

--- a/src/smooth.cpp
+++ b/src/smooth.cpp
@@ -683,6 +683,7 @@ odgi::graph_t smooth_and_lace(const xg::XG &graph,
 
                                     if (fraction_contiguous_path < min_fraction_contiguous_paths){
                                         merged = false;
+                                        prep_new_merge_group = !is_last_block;
                                         fraction_below_threshold = true;
                                     }
                                 }
@@ -722,6 +723,10 @@ odgi::graph_t smooth_and_lace(const xg::XG &graph,
                                 out_maf << "a blocks=" << block_id_range << " loops=false";
                                 if (merged_maf_blocks_size > 1) {
                                     out_maf << " merged=true";
+
+                                    if (fraction_below_threshold) {
+                                        out_maf << " below_thresh=true";
+                                    }
                                 }
                                 out_maf << std::endl;
 
@@ -822,12 +827,7 @@ odgi::graph_t smooth_and_lace(const xg::XG &graph,
 
                         if (!merged && !prep_new_merge_group) {
                             if (produce_maf){
-                                out_maf << "a blocks=" + std::to_string(block_id) << " loops=" << (contains_loops ? "true" : "false");
-                                if (fraction_below_threshold) {
-                                    out_maf << " below_thresh=true";
-                                }
-
-                                out_maf << std::endl;
+                                out_maf << "a blocks=" + std::to_string(block_id) << " loops=" << (contains_loops ? "true" : "false") << std::endl;
                                 write_maf_rows(out_maf, mafs[block_id]);
                             }
 

--- a/src/smooth.cpp
+++ b/src/smooth.cpp
@@ -577,7 +577,7 @@ odgi::graph_t smooth_and_lace(const xg::XG &graph,
                               int poa_q, int poa_c,
                               bool local_alignment,
                               std::string &path_output_maf, std::string &maf_header,
-                              bool merge_blocks, double min_fraction_contiguous_paths,
+                              bool merge_blocks, double contiguous_path_jaccard,
                               bool use_abpoa,
                               const std::string &consensus_base_name) {
 
@@ -669,19 +669,10 @@ odgi::graph_t smooth_and_lace(const xg::XG &graph,
                                 }
 
                                 if (merged){
-                                    double fraction_contiguous_path = (double) num_contiguous_seq /
+                                    double current_contiguous_path_jaccard = (double) num_contiguous_seq /
                                             (double)(num_seq_in_block - (add_consensus ? 1 : 0) + merged_maf_blocks.rows.size() - num_contiguous_seq);
 
-                                    /*std::cerr << "block_id: " << block_id << std::endl;
-                                    std::cerr << "\tnum_contiguous_seq: " << num_contiguous_seq << std::endl;
-                                    std::cerr << "\tdenominator: " <<
-                                        (double)(num_seq_in_block - (add_consensus ? 1 : 0) + merged_maf_blocks.rows.size() - num_contiguous_seq) << std::endl;
-                                    std::cerr << "\tfraction_contiguous_path: " << fraction_contiguous_path << std::endl;
-                                    std::cerr << "\tmerged: " << merged << std::endl;
-                                    std::cerr << "\tfraction_contiguous_path >= min_fraction_contiguous_paths: " <<
-                                        (fraction_contiguous_path >= min_fraction_contiguous_paths) << std::endl << std::endl;*/
-
-                                    if (fraction_contiguous_path < min_fraction_contiguous_paths){
+                                    if (current_contiguous_path_jaccard < contiguous_path_jaccard){
                                         merged = false;
                                         prep_new_merge_group = !is_last_block;
                                         fraction_below_threshold = true;

--- a/src/smooth.cpp
+++ b/src/smooth.cpp
@@ -639,7 +639,7 @@ odgi::graph_t smooth_and_lace(const xg::XG &graph,
                             if (merged_maf_blocks.field_blocks.empty()){
                                 merged = true;
                             } else {
-                                // The block to merge must have no new paths respect to the merged groupW
+                                // The block to merge must have no new paths respect to the merged group
                                 merged = true;
 
                                 uint64_t num_contiguous_seq = 0;

--- a/src/smooth.cpp
+++ b/src/smooth.cpp
@@ -641,6 +641,8 @@ odgi::graph_t smooth_and_lace(const xg::XG &graph,
                                 // The block to merge must have no new paths respect to the merged groupW
                                 merged = true;
 
+                                uint64_t num_contiguous_seq = 0;
+
                                 for (uint64_t i = 0; i < num_seq_in_block; i++) {
                                     // Do not check the consensus (always forward)
                                     if (!add_consensus || i < num_seq_in_block - 1) {
@@ -659,8 +661,24 @@ odgi::graph_t smooth_and_lace(const xg::XG &graph,
                                                 prep_new_merge_group = !is_last_block;
                                                 break;
                                             }
+
+                                            num_contiguous_seq += 1;
                                         }
                                     }
+                                }
+
+                                double fraction_contiguous_path = (double) num_contiguous_seq / (double)(num_seq_in_block - (add_consensus ? 1 : 0));
+
+                                /*std::cerr << "block_id: " << block_id << std::endl;
+                                std::cerr << "\tnum_contiguous_seq: " << num_contiguous_seq << std::endl;
+                                std::cerr << "\tdenominator: " << (num_seq_in_block - (add_consensus ? 1 : 0)) << std::endl;
+                                std::cerr << "\tfraction_contiguous_path: " << fraction_contiguous_path << std::endl;
+                                std::cerr << "\tmerged: " << merged << std::endl;
+                                std::cerr << "\tfraction_contiguous_path >= min_fraction_contiguous_paths: " <<
+                                    (fraction_contiguous_path >= min_fraction_contiguous_paths) << std::endl << std::endl;*/
+
+                                if (merged && fraction_contiguous_path < min_fraction_contiguous_paths){
+                                    merged = false;
                                 }
                             }
                         }

--- a/src/smooth.cpp
+++ b/src/smooth.cpp
@@ -633,6 +633,7 @@ odgi::graph_t smooth_and_lace(const xg::XG &graph,
 
                     bool prep_new_merge_group = false;
                     bool merged = false;
+                    bool fraction_below_threshold = false;
                     if (merge_blocks){
                         if (!contains_loops) {
                             if (merged_maf_blocks.field_blocks.empty()){
@@ -682,6 +683,7 @@ odgi::graph_t smooth_and_lace(const xg::XG &graph,
 
                                     if (fraction_contiguous_path < min_fraction_contiguous_paths){
                                         merged = false;
+                                        fraction_below_threshold = true;
                                     }
                                 }
                             }

--- a/src/smooth.hpp
+++ b/src/smooth.hpp
@@ -54,7 +54,8 @@ odgi::graph_t smooth_and_lace(const xg::XG &graph,
                               int poa_g, int poa_e,
                               int poa_q, int poa_c,
                               bool local_alignment,
-                              std::string &path_output_maf, std::string &maf_header, bool merge_blocks,
+                              std::string &path_output_maf, std::string &maf_header,
+                              bool merge_blocks, double min_fraction_contiguous_paths,
                               bool use_abpoa = true,
                               const std::string &consensus_name = "");
 

--- a/src/smooth.hpp
+++ b/src/smooth.hpp
@@ -55,7 +55,7 @@ odgi::graph_t smooth_and_lace(const xg::XG &graph,
                               int poa_q, int poa_c,
                               bool local_alignment,
                               std::string &path_output_maf, std::string &maf_header,
-                              bool merge_blocks, double min_fraction_contiguous_paths,
+                              bool merge_blocks, double contiguous_path_jaccard,
                               bool use_abpoa = true,
                               const std::string &consensus_name = "");
 


### PR DESCRIPTION
Now the MAF blocks / consensus sequences merge is disable by default.

Specifying the `-M/--merge-blocks` flag, a gentle merge mode is enabled: to be merged, a new block has to have all its paths contiguous to the paths in the group of the already merged blocks.

Such a behaviour can be modulated with the `-J/--contiguous-path-jaccard` options (`1.0` by default). Lower values correspond to more aggressive merge modes.

Little example

**example.gfa**
```
H	VN:Z:1.0
S	1	CAAATAAG
S	2	A
S	3	GCT
S	4	T
S	5	C
S	6	TTG
S	7	A
S	8	G
S	9	AAATTTTCTGGA
P	x	1+,3+,5+	*
P	y	1+,3+,4+,6+,8+,9+	*
P	z	2+,3+,5+,9+	*
```


**contiguous-path-jaccard 1.0 (gentle merge)**
```
smoothxg -M -F 1.0 -g example.gfa -m example.F_1.maf -n -a -w 3 > smooth.F_1.gfa
cat example.F_1.maf
```
```
##maf version=1
# smoothxg
# input=example.gfa sequences=3
# merge_blocks=true min_fraction_contiguous_paths=1.000000
# POA=abPOA alignment_mode=global order_paths=from_shortest
# max_block_weight=3 max_block_jump=5000 min_subpath=0 max_edge_jump=5000
# max_poa_length=10000 min_copy_length=1000 max_copy_length=20000 min_autocorr_z=5 autocorr_stride=50

a blocks=0-1 loops=false merged=true below_thresh=true
s x              0 12 + 12 CAAATAAGGCTC
s y              0 12 + 28 CAAATAAGGCTT
s z              0  5 + 17 ------A-GCTC
s Consensus_0    0  8 +  8 CAAATAAG----
s Consensus_1    0  4 +  4 --------GCTC
s Consensus_0-1  0 12 + 12 CAAATAAGGCTC

a blocks=2 loops=false
s y           12 4 + 28 TTGG
s Consensus_2  0 4 +  4 TTGG

a blocks=3 loops=false
s y           16 12 + 28 AAATTTTCTGGA
s z            5 12 + 17 AAATTTTCTGGA
s Consensus_3  0 12 + 12 AAATTTTCTGGA
```

**contiguous-path-jaccard 0.5 (intermediate mode)**
```
smoothxg -M -F 0.5 -g example.gfa -m example.F_05.maf -n -a -w 3 > smooth.F_05.gfa
cat example.F_05.maf
```
```
##maf version=1
# smoothxg
# input=example.gfa sequences=3
# merge_blocks=true min_fraction_contiguous_paths=0.500000
# POA=abPOA alignment_mode=global order_paths=from_shortest
# max_block_weight=3 max_block_jump=5000 min_subpath=0 max_edge_jump=5000
# max_poa_length=10000 min_copy_length=1000 max_copy_length=20000 min_autocorr_z=5 autocorr_stride=50

a blocks=0-1 loops=false merged=true below_thresh=true
s x              0 12 + 12 CAAATAAGGCTC
s y              0 12 + 28 CAAATAAGGCTT
s z              0  5 + 17 ------A-GCTC
s Consensus_0    0  8 +  8 CAAATAAG----
s Consensus_1    0  4 +  4 --------GCTC
s Consensus_0-1  0 12 + 12 CAAATAAGGCTC

a blocks=2-3 loops=false merged=true
s y              12 16 + 28 TTGGAAATTTTCTGGA
s z               5 12 + 17 ----AAATTTTCTGGA
s Consensus_2     0  4 +  4 TTGG------------
s Consensus_3     0 12 + 12 ----AAATTTTCTGGA
s Consensus_2-3   0 16 + 16 TTGGAAATTTTCTGGA
```

**contiguous-path-jaccard 0.0 (aggressive merge)**
```
smoothxg -M -F 0 -g example.gfa -m example.F_0.maf -n -a -w 3 > smooth.F_0.gfa
cat example.F_0.maf
```
```
##maf version=1
# smoothxg
# input=example.gfa sequences=3
# merge_blocks=true min_fraction_contiguous_paths=0.000000
# POA=abPOA alignment_mode=global order_paths=from_shortest
# max_block_weight=3 max_block_jump=5000 min_subpath=0 max_edge_jump=5000
# max_poa_length=10000 min_copy_length=1000 max_copy_length=20000 min_autocorr_z=5 autocorr_stride=50

a blocks=0-3 loops=false merged=true
s x              0 12 + 12 CAAATAAGGCTC----------------
s y              0 28 + 28 CAAATAAGGCTTTTGGAAATTTTCTGGA
s z              0 17 + 17 ------A-GCTC----AAATTTTCTGGA
s Consensus_0    0  8 +  8 CAAATAAG--------------------
s Consensus_1    0  4 +  4 --------GCTC----------------
s Consensus_2    0  4 +  4 ------------TTGG------------
s Consensus_3    0 12 + 12 ----------------AAATTTTCTGGA
s Consensus_0-3  0 28 + 28 CAAATAAGGCTCTTGGAAATTTTCTGGA
```