### PR TITLE
don't break when there's only one sequence in the block

### DIFF
--- a/src/breaks.cpp
+++ b/src/breaks.cpp
@@ -123,7 +123,7 @@ void break_blocks(const xg::XG& graph,
                     break;
                 }
             }
-            if (to_break) {
+            if (block.path_ranges.size() > 1 && to_break) {
                 ++n_cut_blocks;
                 uint64_t cut_length = max_poa_length;
                 bool found_repeat = false;


### PR DESCRIPTION
Breaking these doesn't matter, and it results in *crazy* structures in the graph that are just arbitrary misalignments of the single sequence.

(There are still issues with broken blocks / repeat blocks to be solved with a change to the POA algorithm.)