### PR TITLE
Cluster POA using spanning minimum identity

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -46,3 +46,6 @@
 [submodule "deps/abPOA"]
 	path = deps/abPOA
 	url = https://github.com/ekg/abPOA
+[submodule "deps/edlib"]
+	path = deps/edlib
+	url = https://github.com/Martinsos/edlib.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -229,6 +229,8 @@ set(abPOA_INCLUDE "${CMAKE_SOURCE_DIR}/abPOA/include")
 # set(abPOA_src_INCLUDE "${CMAKE_SOURCE_DIR}/abPOA/src")
 set(abPOA_LIB "${INSTALL_DIR}/src/abPOA-build/lib")
 
+add_subdirectory(deps/edlib EXCLUDE_FROM_ALL)
+
 set(CMAKE_BUILD_TYPE Debug)
 #set(CMAKE_BUILD_TYPE Release)
 
@@ -313,7 +315,8 @@ set(smoothxg_INCLUDES
   "${sautocorr_INCLUDE}"
   "${abPOA_INCLUDE}"
   "${abPOA_src_INCLUDE}"
-  "${bbhash_INCLUDE}")
+  "${bbhash_INCLUDE}"
+  "deps/edlib/edlib/include")
 
 set(smoothxg_LIBS
   "${sdsl-lite_LIB}/libsdsl.a"
@@ -331,6 +334,7 @@ add_executable(smoothxg
   ${CMAKE_SOURCE_DIR}/src/main.cpp)
 target_link_libraries(smoothxg spoa)
 target_link_libraries(smoothxg ${smoothxg_LIBS})
+target_link_libraries(smoothxg edlib)
 
 # -lz is needed for abPOA, as indicated in the example.c
 # https://github.com/yangao07/abPOA/blob/17d7b287b905bcd0e684ca5015a78e5a73a40798/example.c#L3

--- a/src/breaks.cpp
+++ b/src/breaks.cpp
@@ -220,7 +220,7 @@ void break_blocks(const xg::XG& graph,
                     groups.push_back({i});
                 }
             }
-            if (false && groups.size() == 1) {
+            if (groups.size() == 1) {
                 // nothing to do
                 {
                     std::lock_guard<std::mutex> guard(new_blocks_mutex);

--- a/src/breaks.cpp
+++ b/src/breaks.cpp
@@ -22,108 +22,7 @@ void break_blocks(const xg::XG& graph,
 
     const VectorizableHandleGraph& vec_graph = dynamic_cast<const VectorizableHandleGraph&>(graph);
 
-    std::stringstream splits_banner;
-    splits_banner << "[smoothxg::break_blocks] splitting short sequences out of " << blocks.size() << " blocks:";
-    progress_meter::ProgressMeter splits_progress(blocks.size(), splits_banner.str());
-
-    std::atomic<uint64_t> split_blocks;
-    split_blocks.store(0);
-    std::mutex new_blocks_mutex;
-    std::vector<std::pair<double, block_t>> new_blocks;
-    paryfor::parallel_for<uint64_t>(
-        0, blocks.size(), thread_count,
-        [&](uint64_t block_id, int tid) {
-            //for (auto& block : blocks) {
-            auto &block = blocks[block_id];
-            // ensure that the sequences in the block
-            // are within our identity threshold
-            // if not, peel them off into splits
-            //EdlibAlignResult result = edlibAlign("hello", 5, "world!", 6, edlibDefaultAlignConfig());
-            std::vector<std::string> seqs;
-            for (auto& path_range : block.path_ranges) {
-                std::string name = graph.get_path_name(graph.get_path_handle_of_step(path_range.begin));
-                seqs.emplace_back();
-                auto& seq = seqs.back();
-                for (step_handle_t step = path_range.begin;
-                     step != path_range.end;
-                     step = graph.get_next_step(step)) {
-                    seq.append(graph.get_sequence(graph.get_handle_of_step(step)));
-                }
-            }
-            std::vector<std::vector<uint64_t>> groups;
-            // iterate through the seqs
-            // for each sequence try to match it to a group at the given identity threshold
-            // if we can't get it to match, add a new group
-            groups.emplace_back();
-            groups.back().push_back(0); // seed with the first sequence
-            for (uint64_t i = 1; i < seqs.size(); ++i) {
-                auto& curr = seqs[i];
-                uint64_t best_group = 0;
-                double best_id = -1;
-                for (uint64_t j = 0; j < groups.size(); ++j) {
-                    auto& group = groups[j];
-                    for (uint64_t k = 0; k < group.size(); ++k) {
-                        auto& other = seqs[k];
-                        EdlibAlignResult result = edlibAlign(curr.c_str(), curr.size(), other.c_str(), other.size(),
-                                                             edlibNewAlignConfig(-1, EDLIB_MODE_HW, EDLIB_TASK_DISTANCE, NULL, 0));
-                        if (result.status == EDLIB_STATUS_OK) {
-                            double id = (double)(curr.size() - result.editDistance) / (double)curr.size();
-                            if (id > best_id) {
-                                best_group = j;
-                                best_id = id;
-                            }
-                        }
-                    }
-                }
-                if (best_id > 0) {
-                    groups[best_group].push_back(i);
-                } else {
-                    groups.push_back({i});
-                }
-            }
-            if (groups.size() == 1) {
-                // nothing to do
-                {
-                    std::lock_guard<std::mutex> guard(new_blocks_mutex);
-                    new_blocks.push_back(std::make_pair(block_id, block));
-                }
-            } else {
-                ++split_blocks;
-                uint64_t i = 0;
-                for (auto& group : groups) {
-                    block_t new_block;
-                    new_block.is_split = true;
-                    for (auto& i : group) {
-                        new_block.path_ranges.push_back(block.path_ranges[i]);
-                    }
-                    for (auto& path_range : new_block.path_ranges) {
-                        new_block.total_path_length += path_range.length;
-                        new_block.max_path_length = std::max(new_block.max_path_length,
-                                                             path_range.length);
-                    }
-                    {
-                        std::lock_guard<std::mutex> guard(new_blocks_mutex);
-                        new_blocks.push_back(std::make_pair(block_id + i++ * (1.0/groups.size()), new_block));
-                    }
-                }
-            }
-            splits_progress.increment(1);
-        });
-    splits_progress.finish();
-    std::vector<block_t>().swap(blocks); // clear blocks
-    ips4o::parallel::sort(
-        new_blocks.begin(), new_blocks.end(),
-        [](const std::pair<double, block_t>& a,
-           const std::pair<double, block_t>& b) {
-            return a.first < b.first;
-        });
-    for (auto& p : new_blocks) {
-        blocks.push_back(p.second);
-    }
-    std::vector<std::pair<double, block_t>>().swap(new_blocks); // clear new_blocks
-
-    std::cerr << "[smoothxg::break_blocks] split " << split_blocks << " blocks" << std::endl;
-    std::cerr << "[smoothxg::break_blocks] cutting blocks that contain sequences longer than max-poa-length (" << max_poa_length << ")" << std::endl;
+        std::cerr << "[smoothxg::break_blocks] cutting blocks that contain sequences longer than max-poa-length (" << max_poa_length << ")" << std::endl;
     
     std::stringstream breaks_banner;
     breaks_banner << "[smoothxg::break_blocks] cutting " << blocks.size() << " blocks:";
@@ -262,6 +161,112 @@ void break_blocks(const xg::XG& graph,
         });
     breaks_progress.finish();
     std::cerr << "[smoothxg::break_blocks] cut " << n_cut_blocks << " blocks of which " << n_repeat_blocks << " had repeats" << std::endl;
+
+    std::stringstream splits_banner;
+    splits_banner << "[smoothxg::break_blocks] splitting " << blocks.size() << " blocks at identity " << block_group_identity << ":";
+    progress_meter::ProgressMeter splits_progress(blocks.size(), splits_banner.str());
+
+    std::atomic<uint64_t> split_blocks;
+    split_blocks.store(0);
+    std::mutex new_blocks_mutex;
+    std::vector<std::pair<double, block_t>> new_blocks;
+    paryfor::parallel_for<uint64_t>(
+        0, blocks.size(), thread_count,
+        [&](uint64_t block_id, int tid) {
+            //for (auto& block : blocks) {
+            auto &block = blocks[block_id];
+            // ensure that the sequences in the block
+            // are within our identity threshold
+            // if not, peel them off into splits
+            std::vector<std::string> seqs;
+            for (auto& path_range : block.path_ranges) {
+                std::string name = graph.get_path_name(graph.get_path_handle_of_step(path_range.begin));
+                seqs.emplace_back();
+                auto& seq = seqs.back();
+                for (step_handle_t step = path_range.begin;
+                     step != path_range.end;
+                     step = graph.get_next_step(step)) {
+                    seq.append(graph.get_sequence(graph.get_handle_of_step(step)));
+                }
+            }
+            std::vector<std::vector<uint64_t>> groups;
+            // iterate through the seqs
+            // for each sequence try to match it to a group at the given identity threshold
+            // if we can't get it to match, add a new group
+            groups.push_back({0}); // seed with the first sequence
+            for (uint64_t i = 1; i < seqs.size(); ++i) {
+                auto& curr = seqs[i];
+                uint64_t best_group = 0;
+                double best_id = -1;
+                for (uint64_t j = 0; j < groups.size(); ++j) {
+                    auto& group = groups[j];
+                    for (uint64_t k = 0; k < group.size(); ++k) {
+                        auto& other = seqs[group[k]];
+                        EdlibAlignResult result = edlibAlign(curr.c_str(), curr.size(), other.c_str(), other.size(),
+                                                             edlibNewAlignConfig(-1, EDLIB_MODE_HW, EDLIB_TASK_DISTANCE, NULL, 0));
+                        if (result.status == EDLIB_STATUS_OK) {
+                            //double id = (double)((curr.size()+other.size()) - result.editDistance) / (double)(curr.size()+other.size());
+                            double id = (double)(other.size() - result.editDistance) / (double)(other.size());
+                            if (id >= block_group_identity && id > best_id) {
+                                best_group = j;
+                                best_id = id;
+                            }
+                        }
+                    }
+                }
+                if (best_id > 0) {
+                    groups[best_group].push_back(i);
+                } else {
+                    groups.push_back({i});
+                }
+            }
+            if (false && groups.size() == 1) {
+                // nothing to do
+                {
+                    std::lock_guard<std::mutex> guard(new_blocks_mutex);
+                    new_blocks.push_back(std::make_pair(block_id, block));
+                }
+            } else {
+                ++split_blocks;
+                uint64_t i = 0;
+                for (auto& group : groups) {
+                    block_t new_block;
+                    //new_block.is_split = true;
+                    /*
+                    std::cerr << "group " << i << " contains ";
+                    for (auto& j : group) std::cerr << " " << j;
+                    std::cerr << std::endl;
+                    */
+                    for (auto& j : group) {
+                        new_block.path_ranges.push_back(block.path_ranges[j]);
+                    }
+                    for (auto& path_range : new_block.path_ranges) {
+                        new_block.total_path_length += path_range.length;
+                        new_block.max_path_length = std::max(new_block.max_path_length,
+                                                             path_range.length);
+                    }
+                    {
+                        std::lock_guard<std::mutex> guard(new_blocks_mutex);
+                        new_blocks.push_back(std::make_pair(block_id + i++ * (1.0/groups.size()), new_block));
+                    }
+                }
+            }
+            splits_progress.increment(1);
+        });
+    splits_progress.finish();
+    std::vector<block_t>().swap(blocks); // clear blocks
+    ips4o::parallel::sort(
+        new_blocks.begin(), new_blocks.end(),
+        [](const std::pair<double, block_t>& a,
+           const std::pair<double, block_t>& b) {
+            return a.first < b.first;
+        });
+    for (auto& p : new_blocks) {
+        blocks.push_back(p.second);
+    }
+    std::vector<std::pair<double, block_t>>().swap(new_blocks); // clear new_blocks
+
+    std::cerr << "[smoothxg::break_blocks] split " << split_blocks << " blocks" << std::endl;
 }
 
 }

--- a/src/breaks.cpp
+++ b/src/breaks.cpp
@@ -203,10 +203,12 @@ void break_blocks(const xg::XG& graph,
                     for (uint64_t k = 0; k < group.size(); ++k) {
                         auto& other = seqs[group[k]];
                         EdlibAlignResult result = edlibAlign(curr.c_str(), curr.size(), other.c_str(), other.size(),
-                                                             edlibNewAlignConfig(-1, EDLIB_MODE_HW, EDLIB_TASK_DISTANCE, NULL, 0));
-                        if (result.status == EDLIB_STATUS_OK) {
+                                                             edlibNewAlignConfig(-1, EDLIB_MODE_NW, EDLIB_TASK_DISTANCE, NULL, 0));
+                        if (result.status == EDLIB_STATUS_OK
+                            && result.editDistance >= 0) {
                             //double id = (double)((curr.size()+other.size()) - result.editDistance) / (double)(curr.size()+other.size());
-                            double id = (double)(other.size() - result.editDistance) / (double)(other.size());
+                            // TODO FIx should be max of other and curr size
+                            double id = (double)(curr.size() - result.editDistance) / (double)(curr.size());
                             if (id >= block_group_identity && id > best_id) {
                                 best_group = j;
                                 best_id = id;

--- a/src/breaks.hpp
+++ b/src/breaks.hpp
@@ -9,6 +9,7 @@
 #include <vector>
 #include <numeric>
 #include <cmath>
+#include "edlib.h"
 #include "blocks.hpp"
 #include "sautocorr.hpp"
 #include "xg.hpp"
@@ -22,6 +23,7 @@ using namespace handlegraph;
 // and break the path ranges to be shorter than our "max" sequence size input to spoa
 void break_blocks(const xg::XG& graph,
                   std::vector<block_t>& blocks,
+                  const double& block_group_identity,
                   const uint64_t& max_poa_length,
                   const uint64_t& min_copy_length,
                   const uint64_t& max_copy_length,
@@ -29,7 +31,6 @@ void break_blocks(const xg::XG& graph,
                   const uint64_t& autocorr_stride,
                   const bool& order_paths_from_longest,
                   const bool& break_repeats,
-                  const double& min_segment_ratio,
                   const uint64_t& thread_count,
                   const bool& consensus_graph);
 

--- a/src/breaks.hpp
+++ b/src/breaks.hpp
@@ -14,6 +14,7 @@
 #include "sautocorr.hpp"
 #include "xg.hpp"
 #include "paryfor.hpp"
+#include "odgi/dna.hpp"
 
 namespace smoothxg {
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -59,7 +59,7 @@ int main(int argc, char** argv) {
     args::ValueFlag<float> _prep_sgd_min_term_updates(parser, "N", "path-guided SGD sort quality parameter (N * sum_path_length updates per iteration) for graph prep [default: 1]", {'U', "path-sgd-term-updates"});
     args::Flag use_spoa(parser, "use-spoa", "run spoa (in local alignment mode) instead of abPOA (in global alignment mode) for smoothing", {'S', "spoa"});
     args::Flag change_alignment_mode(parser, "change-alignment-mode", "change the alignment mode of spoa to global, the local alignment mode of abpoa is currently not supported", {'Z', "change-alignment-mode"});
-    args::Flag no_toposort(parser, "no-toposort", "don't apply topological sorting in the sort pipeline", {'T', "no-toposort"});
+    args::Flag no_toposort(parser, "prep-no-toposort", "do not apply topological sorting in the prep sort pipeline", {'T', "prep-no-toposort"});
     args::Flag validate(parser, "validate", "validate construction", {'V', "validate"});
     args::Flag keep_temp(parser, "keep-temp", "keep temporary files", {'K', "keep-temp"});
     args::Flag debug(parser, "debug", "enable debugging", {'d', "debug"});

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -48,7 +48,8 @@ int main(int argc, char** argv) {
     args::ValueFlag<uint64_t> _max_block_jump(parser, "N", "maximum path jump to include in block [default: 5000]", {'j', "path-jump-max"});
     args::ValueFlag<uint64_t> _min_subpath(parser, "N", "minimum length of a subpath to include in partial order alignment [default: 0 / no filter]", {'k', "subpath-min"});
     args::ValueFlag<uint64_t> _max_edge_jump(parser, "N", "maximum edge jump before breaking [default: 5000]", {'e', "edge-jump-max"});
-    args::ValueFlag<double> _min_segment_ratio(parser, "N", "split out segments in a block that are less than this fraction of the length of the longest path range in the block [default: 0.1]", {'R', "min-segment-ratio"});
+    //args::ValueFlag<double> _min_segment_ratio(parser, "N", "split out segments in a block that are less than this fraction of the length of the longest path range in the block [default: 0.1]", {'R', "min-segment-ratio"});
+    args::ValueFlag<double> _block_group_identity(parser, "N", "minimum edit-based identity to group sequences in POA [default: 0.5]", {'I', "block-id-min"});
     args::ValueFlag<uint64_t> _min_copy_length(parser, "N", "minimum repeat length to collapse [default: 1000]", {'c', "copy-length-min"});
     args::ValueFlag<uint64_t> _max_copy_length(parser, "N", "maximum repeat length to attempt to detect [default: 20000]", {'W', "copy-length-max"});
     args::ValueFlag<uint64_t> _max_poa_length(parser, "N", "maximum sequence length to put into poa [default: 10000]", {'l', "poa-length-max"});
@@ -124,7 +125,7 @@ int main(int argc, char** argv) {
     uint64_t min_copy_length = _min_copy_length ? args::get(_min_copy_length) : 1000;
     uint64_t max_copy_length = _max_copy_length ? args::get(_max_copy_length) : 20000;
     uint64_t max_poa_length = _max_poa_length ? args::get(_max_poa_length) : 10000;
-    double min_segment_ratio = _min_segment_ratio ? args::get(_min_segment_ratio) : 0.1;
+    double block_group_identity =  _block_group_identity ? args::get(_block_group_identity) : 0.5;
 
     if (!args::get(use_spoa) && args::get(change_alignment_mode)) {
         std::cerr
@@ -219,6 +220,7 @@ int main(int argc, char** argv) {
     uint64_t autocorr_stride = 50;
     smoothxg::break_blocks(graph,
                            blocks,
+                           block_group_identity,
                            max_poa_length,
                            min_copy_length,
                            max_copy_length,
@@ -226,7 +228,6 @@ int main(int argc, char** argv) {
                            autocorr_stride,
                            order_paths_from_longest,
                            true,
-                           min_segment_ratio,
                            n_threads,
                            write_consensus_graph);
 

--- a/src/smooth.cpp
+++ b/src/smooth.cpp
@@ -1063,7 +1063,7 @@ odgi::graph_t smooth_and_lace(const xg::XG &graph,
                << " to " << blocks.size() << " blocks:";
     progress_meter::ProgressMeter poa_progress(blocks.size(), poa_banner.str());
 
-#pragma omp parallel for schedule(guided)
+#pragma omp parallel for schedule(dynamic,1)
     for (uint64_t i = 0; i < blocks.size(); ++i) {
         uint64_t block_id = i;
         auto &block = blocks[block_id];

--- a/src/smooth.cpp
+++ b/src/smooth.cpp
@@ -1063,7 +1063,7 @@ odgi::graph_t smooth_and_lace(const xg::XG &graph,
                << " to " << blocks.size() << " blocks:";
     progress_meter::ProgressMeter poa_progress(blocks.size(), poa_banner.str());
 
-#pragma omp parallel for schedule(static,1)
+#pragma omp parallel for schedule(guided)
     for (uint64_t i = 0; i < blocks.size(); ++i) {
         uint64_t block_id = i;
         auto &block = blocks[block_id];


### PR DESCRIPTION
Require all sequences going into a single POA problem to be connected by edit-based identities of at least `-I[N], --block-id-min=[N]`.

This mitigates spurious long-range or mid-SV alignments, and lets us define a bound for the relationship based on the pairwise distances between the sequences. A graph with higher `--block-id-min` will be more "unfolded" and also "smoother" but this can increase graph size.