### PR TITLE
free the edlib alignment result

### DIFF
--- a/src/breaks.cpp
+++ b/src/breaks.cpp
@@ -218,6 +218,7 @@ void break_blocks(const xg::XG& graph,
                                     best_id = id;
                                 }
                             }
+                            edlibFreeAlignResult(result);
                         }
                     }
                 }


### PR DESCRIPTION
This should fix out of memory errors in the block splitting step.