### PR TITLE
read/write POA blocks on disk, code refactoring and bug fixing

### DIFF
--- a/src/blocks.cpp
+++ b/src/blocks.cpp
@@ -258,14 +258,6 @@ void smoothable_blocks(
         finalize_block(block, block_handles);
     }
 
-    /*blocks.erase(
-        std::remove_if(
-            blocks.begin(), blocks.end(),
-            [&](const block_t& block) {
-                return block.total_path_length == 0;
-            }),
-        blocks.end());*/
-
     // at the end, we'll be left with some fragments of paths that aren't included in any blocks
     // that's ok, but we should see how much of a problem it is / should they be compressed?
 

--- a/src/blocks.cpp
+++ b/src/blocks.cpp
@@ -70,7 +70,7 @@ void smoothable_blocks(
             std::vector<path_range_t> path_ranges;
             for (auto& step : traversals) {
                 if (path_ranges.empty()) {
-                    path_ranges.push_back({step, step, 0, 0, 0, 0});
+                    path_ranges.push_back({step, step, 0, 0, 0});
                 } else {
                     auto& path_range = path_ranges.back();
                     auto& last = path_range.end;
@@ -79,7 +79,7 @@ void smoothable_blocks(
                             - (graph.get_position_of_step(last) + graph.get_length(graph.get_handle_of_step(last)))
                             > max_path_jump)) {
                         // make a new range
-                        path_ranges.push_back({step, step, 0, 0, 0, 0});
+                        path_ranges.push_back({step, step, 0, 0, 0});
                     } else {
                         // extend the range
                         last = step;

--- a/src/blocks.cpp
+++ b/src/blocks.cpp
@@ -124,7 +124,7 @@ smoothable_blocks(
 
             // finally, mark which steps we've kept and record the total length
             block.total_path_length = 0; // recalculate how much sequence we have
-            block.max_path_length = 0; // and the longest path range
+            //block.max_path_length = 0; // and the longest path range
             for (auto& path_range : block.path_ranges) {
                 auto& included_path_length = path_range.length;
                 included_path_length = 0;
@@ -143,8 +143,7 @@ smoothable_blocks(
                     included_path_length += graph.get_length(graph.get_handle_of_step(curr_step));
                 }
                 block.total_path_length += included_path_length;
-                block.max_path_length = std::max(included_path_length,
-                                                 block.max_path_length);
+                //block.max_path_length = std::max(included_path_length, block.max_path_length);
             }
             //std::cerr << "max_path_length " << block.max_path_length << std::endl;
 

--- a/src/blocks.cpp
+++ b/src/blocks.cpp
@@ -190,12 +190,14 @@ void smoothable_blocks(
                     << graph.get_node_count() << " handles:";
     progress_meter::ProgressMeter blocks_progress(graph.get_node_count(), blocks_banner.str());
 
-    uint64_t total_path_length;
+    uint64_t total_path_length = 0;
 
+    bool first_block = true;
     graph.for_each_handle(
         [&](const handle_t& handle) {
-            if (block_handles.empty()) {
-                total_path_length = 0;
+            if (first_block) {
+                first_block = false;
+
                 block_handles.push_back(handle);
             } else {
                 // how much sequence would we be adding to the block?
@@ -239,7 +241,6 @@ void smoothable_blocks(
                     // if so, finalize the last block and add the new one
                     finalize_block(block, block_handles);
 
-                    block.path_ranges.clear();
                     total_path_length = 0;
                     block_handles.push_back(handle);
                 } else {

--- a/src/blocks.cpp
+++ b/src/blocks.cpp
@@ -15,7 +15,7 @@ smoothable_blocks(
     ) {
     // iterate over the handles in their vectorized order, collecting blocks that we can potentially smooth
     std::vector<block_t> blocks;
-    std::vector<std::vector<handle_t>> blocks_handles;
+    std::vector<handle_t> block_handles;
     std::vector<sdsl::bit_vector> seen_steps(graph.get_path_count());
 
     // cast to vectorizable graph for determining the sort position of nodes
@@ -189,8 +189,6 @@ smoothable_blocks(
             if (blocks.empty()) {
                 blocks.emplace_back();
 
-                blocks_handles.emplace_back();
-                auto& block_handles = blocks_handles.back();
                 block_handles.push_back(handle);
             } else {
                 // how much sequence would we be adding to the block?
@@ -223,8 +221,8 @@ smoothable_blocks(
                         int64_t jump = std::abs(other_vec_offset - handle_vec_offset);
                         longest_edge_jump = std::max(longest_edge_jump, jump);
                     });
+
                 auto& block = blocks.back();
-                auto& block_handles = blocks_handles.back();
                 // if we add to the current block, do we go over our total path length?
                 if (block.total_path_length + sequence_to_add > max_block_weight
                     || max_edge_jump && longest_edge_jump > max_edge_jump) {
@@ -237,8 +235,6 @@ smoothable_blocks(
 
                     blocks.emplace_back();
 
-                    blocks_handles.emplace_back();
-                    auto& block_handles = blocks_handles.back();
                     block_handles.push_back(handle);
                 } else {
                     // if not, add and update
@@ -253,10 +249,8 @@ smoothable_blocks(
     blocks_progress.finish();
     
     if (blocks.back().path_ranges.empty()) {
-        finalize_block(blocks.back(), blocks_handles.back());
+        finalize_block(blocks.back(), block_handles);
     }
-
-    blocks_handles.clear();
 
     blocks.erase(
         std::remove_if(

--- a/src/blocks.cpp
+++ b/src/blocks.cpp
@@ -11,7 +11,8 @@ void smoothable_blocks(
     const uint64_t& max_path_jump,
     const uint64_t& min_subpath,
     const uint64_t& max_edge_jump,
-    const bool& order_paths_from_longest
+    const bool& order_paths_from_longest,
+    const int num_threads
     ) {
     // iterate over the handles in their vectorized order, collecting blocks that we can potentially smooth
     block_t block;
@@ -267,6 +268,8 @@ void smoothable_blocks(
 
     // at the end, we'll be left with some fragments of paths that aren't included in any blocks
     // that's ok, but we should see how much of a problem it is / should they be compressed?
+
+    blockset.index(num_threads);
 }
 
 }

--- a/src/blocks.hpp
+++ b/src/blocks.hpp
@@ -84,9 +84,11 @@ public:
         _blocks.open_writer();
     }
 
-    //~blockset_t(){
-    //    std::remove(_path_tmp_blocks.c_str());
-    //}
+    ~blockset_t(){
+        _blocks.close_writer();
+        _blocks.close_reader();
+        std::remove(_path_tmp_blocks.c_str());
+    }
 
     [[nodiscard]] uint64_t size() const {
         return _num_blocks;

--- a/src/blocks.hpp
+++ b/src/blocks.hpp
@@ -22,7 +22,7 @@ inline uint64_t step_rank(const step_handle_t& step) {
 }
 
 struct path_range_t {
-    uint64_t rank;
+    //uint64_t rank;
     step_handle_t begin;
     step_handle_t end;
     uint64_t length;

--- a/src/blocks.hpp
+++ b/src/blocks.hpp
@@ -67,12 +67,20 @@ private:
     uint64_t _num_blocks;
     mmmulti::map<uint64_t, path_range_t> _blocks;
 
+    std::string _path_tmp_blocks;
 public:
-    blockset_t() {
+    blockset_t(const std::string& dir_work = "") {
+        _path_tmp_blocks = dir_work + "temp.blocks";
+        std::remove(_path_tmp_blocks.c_str());
+
         _num_blocks = 0;
-        _blocks.set_base_filename("temp.dat");
+        _blocks.set_base_filename(_path_tmp_blocks);
 
         _blocks.open_writer();
+    }
+
+    ~blockset_t(){
+        std::remove(_path_tmp_blocks.c_str());
     }
 
     [[nodiscard]] uint64_t size() const {

--- a/src/blocks.hpp
+++ b/src/blocks.hpp
@@ -70,7 +70,7 @@ private:
     std::string _path_tmp_blocks;
 public:
     blockset_t(const std::string& dir_work = "") {
-        _path_tmp_blocks = dir_work + "temp.blocks";
+        _path_tmp_blocks = dir_work + ".temp";
         std::remove(_path_tmp_blocks.c_str());
 
         _num_blocks = 0;
@@ -79,15 +79,26 @@ public:
         _blocks.open_writer();
     }
 
-    ~blockset_t(){
-        std::remove(_path_tmp_blocks.c_str());
-    }
+    //~blockset_t(){
+    //    std::remove(_path_tmp_blocks.c_str());
+    //}
+
+    /*blockset_t& operator=(const blockset_t *pr){
+        _num_blocks = pr->_num_blocks;
+        _blocks = &pr->_blocks;
+        _path_tmp_blocks = pr->_path_tmp_blocks;
+
+        return *this;
+    }*/
 
     [[nodiscard]] uint64_t size() const {
         return _num_blocks;
     }
 
     void add_block(const uint64_t block_id, block_t& block) {
+        //if (block_id >= _num_blocks) {
+        //    _num_blocks += 1;
+        //}
         _num_blocks += 1;
 
         for (uint64_t i = 0; i < block.path_ranges.size(); ++i) {
@@ -96,11 +107,11 @@ public:
         }
     }
 
-    void index(const uint64_t num_threads, const uint64_t max_block_id) {
-        _blocks.index(num_threads, max_block_id + 1);
+    void index(const uint64_t num_threads) {
+        _blocks.index(num_threads, _num_blocks);
     }
 
-    block_t get_block(uint64_t block_id) {
+    [[nodiscard]] block_t get_block(uint64_t block_id) const {
         block_t block;
         block.path_ranges = _blocks.values(block_id + 1);
         return block;
@@ -116,6 +127,7 @@ public:
     const uint64_t& max_path_jump,
     const uint64_t& min_subpath,
     const uint64_t& max_edge_jump,
-    const bool& order_paths_from_longest);
+    const bool& order_paths_from_longest,
+    const int num_threads);
 
 }

--- a/src/blocks.hpp
+++ b/src/blocks.hpp
@@ -93,9 +93,6 @@ public:
     }
 
     void add_block(const uint64_t block_id, block_t& block) {
-        //if (block_id >= _num_blocks) {
-        //    _num_blocks += 1;
-        //}
         _num_blocks += 1;
 
         for (uint64_t rank = 0; rank < block.path_ranges.size(); ++rank) {

--- a/src/blocks.hpp
+++ b/src/blocks.hpp
@@ -31,13 +31,13 @@ struct path_range_t {
 };
 
 struct block_t {
-    std::vector<handle_t> handles; // hmmm do we need this?
-    uint64_t total_path_length = 0; // what of this do we "Really" need?
-    //uint64_t max_path_length = 0;
+    //std::vector<handle_t> handles;  // Do we need this? Yes, but not here.
+    uint64_t total_path_length = 0; // Do we need this? Yes, but not here.
+    //uint64_t max_path_length = 0; // Not used.
     std::vector<path_range_t> path_ranges;
     bool broken = false;
     bool is_repeat = false;
-    //bool is_split = false;
+    //bool is_split = false;        // Not used.
 };
 
 class blockset_t {

--- a/src/blocks.hpp
+++ b/src/blocks.hpp
@@ -33,11 +33,11 @@ struct path_range_t {
 struct block_t {
     std::vector<handle_t> handles; // hmmm do we need this?
     uint64_t total_path_length = 0; // what of this do we "Really" need?
-    uint64_t max_path_length = 0;
+    //uint64_t max_path_length = 0;
     std::vector<path_range_t> path_ranges;
     bool broken = false;
     bool is_repeat = false;
-    bool is_split = false;
+    //bool is_split = false;
 };
 
 class blockset_t {

--- a/src/blocks.hpp
+++ b/src/blocks.hpp
@@ -6,7 +6,7 @@
 #include <algorithm>
 #include <cmath>
 #include <vector>
-
+#include "mmmultimap.hpp"
 #include "xg.hpp"
 
 namespace smoothxg {
@@ -22,6 +22,7 @@ inline uint64_t step_rank(const step_handle_t& step) {
 }
 
 struct path_range_t {
+    uint64_t rank;
     step_handle_t begin;
     step_handle_t end;
     uint64_t length;
@@ -30,13 +31,22 @@ struct path_range_t {
 };
 
 struct block_t {
-    std::vector<handle_t> handles;
-    uint64_t total_path_length = 0;
+    std::vector<handle_t> handles; // hmmm do we need this?
+    uint64_t total_path_length = 0; // what of this do we "Really" need?
     uint64_t max_path_length = 0;
     std::vector<path_range_t> path_ranges;
     bool broken = false;
     bool is_repeat = false;
     bool is_split = false;
+};
+
+class blockset_t {
+public:
+    mmmulti::map<uint64_t, path_range_t> blocks;
+    void add_block(const block_t& block);
+    block_t get_block(uint64_t);
+    // todo provide comparison operator<() for path_range_t
+    //    and, maybe? to sort the mmmultimap properly, comparison for std::pair<uint64_t, path_range_t>
 };
 
 // find the boundaries of blocks that we can compress with spoa

--- a/src/blocks.hpp
+++ b/src/blocks.hpp
@@ -32,12 +32,12 @@ struct path_range_t {
 
 struct block_t {
     //std::vector<handle_t> handles;  // Do we need this? Yes, but not here.
-    uint64_t total_path_length = 0; // Do we need this? Yes, but not here.
+    //uint64_t total_path_length = 0; // Do we need this? Yes, but not here.
     //uint64_t max_path_length = 0; // Not used.
     std::vector<path_range_t> path_ranges;
-    bool broken = false;
-    bool is_repeat = false;
-    //bool is_split = false;        // Not used.
+    //bool broken = false;        // Not used.
+    //bool is_repeat = false;     // Not used.
+    //bool is_split = false;      // Not used.
 };
 
 class blockset_t {

--- a/src/breaks.cpp
+++ b/src/breaks.cpp
@@ -23,7 +23,7 @@ void break_blocks(const xg::XG& graph,
     const VectorizableHandleGraph& vec_graph = dynamic_cast<const VectorizableHandleGraph&>(graph);
 
     std::cerr << "[smoothxg::break_and_split_blocks] cutting blocks that contain sequences longer than max-poa-length (" << max_poa_length << ")" << std::endl;
-    std::cerr << "[smoothxg::break_and_split_blocks] splitting " << blockset->size() << " blocks at identity " << block_group_identity << std::endl;
+    std::cerr << std::fixed << std::setprecision(2) << "[smoothxg::break_and_split_blocks] splitting " << blockset->size() << " blocks at identity " << block_group_identity << std::endl;
 
     std::stringstream breaks_and_splits_banner;
     breaks_and_splits_banner << "[smoothxg::break_and_split_blocks] cutting and splitting " << blockset->size() << " blocks:";

--- a/src/breaks.cpp
+++ b/src/breaks.cpp
@@ -178,7 +178,8 @@ void break_blocks(const xg::XG& graph,
             }
             block.path_ranges = chopped_ranges;
             // order the path ranges from longest/shortest to shortest/longest
-            ips4o::parallel::sort(
+            // this gets called lots of times... probably best to make it std::sort or not parallel
+            std::sort(
                     block.path_ranges.begin(), block.path_ranges.end(),
                     order_paths_from_longest
                     ?

--- a/src/breaks.cpp
+++ b/src/breaks.cpp
@@ -31,109 +31,109 @@ void break_blocks(const xg::XG& graph,
 
     uint64_t n_cut_blocks = 0;
     uint64_t n_repeat_blocks = 0;
-    paryfor::parallel_for<uint64_t>(
-        0, blockset->size(), thread_count,
-        [&](uint64_t block_id, int tid) {
-            auto block = blockset->get_block(block_id);
-            // check if we have sequences that are too long
-            bool to_break = false;
-            for (auto& path_range : block.path_ranges) {
-                if (path_range.length > max_poa_length) {
-                    to_break = true;
-                    break;
-                }
+
+#pragma omp parallel for schedule(static,1) num_threads(thread_count)
+    for (uint64_t block_id = 0; block_id < blockset->size(); ++block_id){
+        auto block = blockset->get_block(block_id);
+        // check if we have sequences that are too long
+        bool to_break = false;
+        for (auto& path_range : block.path_ranges) {
+            if (path_range.length > max_poa_length) {
+                to_break = true;
+                break;
             }
-            if (block.path_ranges.size() > 1 && to_break) {
-                ++n_cut_blocks;
-                uint64_t cut_length = max_poa_length;
-                bool found_repeat = false;
-                // otherwise let's see if we've got repeats that we can use to chop things up
-                // find if there is a repeat
-                if (break_repeats) {
-                    std::vector<sautocorr::repeat_t> repeats;
-                    for (auto& path_range : block.path_ranges) {
-                        // steps in id space
-                        std::string seq;
-                        std::string name = graph.get_path_name(graph.get_path_handle_of_step(path_range.begin));
-                        for (step_handle_t step = path_range.begin;
-                             step != path_range.end;
-                             step = graph.get_next_step(step)) {
-                            seq.append(graph.get_sequence(graph.get_handle_of_step(step)));
-                        }
-                        if (seq.length() < 2*min_copy_length) continue;
-                        //std::cerr << "on " << name << "\t" << seq.length() << std::endl;
-                        std::vector<uint8_t> vec(seq.begin(), seq.end());
-                        sautocorr::repeat_t result = sautocorr::repeat(vec,
-                                                                       min_copy_length,
-                                                                       max_copy_length,
-                                                                       min_copy_length,
-                                                                       min_autocorr_z,
-                                                                       autocorr_stride);
-                        repeats.push_back(result);
-                    }
-                    // if there is, set the cut length to some fraction of it
-                    std::vector<double> lengths;
-                    double max_z = 0;
-                    for (auto& repeat : repeats) {
-                        if (repeat.length > 0) {
-                            lengths.push_back(repeat.length);
-                            max_z = std::max(repeat.z_score, max_z);
-                        }
-                    }
-                    found_repeat = !lengths.empty();
-                    if (found_repeat) {
-                        double repeat_length = sautocorr::vec_mean(lengths.begin(), lengths.end());
-                        cut_length = std::round(repeat_length / 2.0);
-                        ++n_repeat_blocks;
-                        //std::cerr << "found repeat of " << repeat_length << " and Z-score " << max_z << " cutting to " << cut_length << std::endl;
-                    } else {
-                        // if not, chop blindly
-                        cut_length = max_poa_length;
-                    }
-                }
-                std::vector<path_range_t> chopped_ranges;
+        }
+        if (block.path_ranges.size() > 1 && to_break) {
+            ++n_cut_blocks;
+            uint64_t cut_length = max_poa_length;
+            bool found_repeat = false;
+            // otherwise let's see if we've got repeats that we can use to chop things up
+            // find if there is a repeat
+            if (break_repeats) {
+                std::vector<sautocorr::repeat_t> repeats;
                 for (auto& path_range : block.path_ranges) {
-
-                    if (!found_repeat && path_range.length < cut_length) {
-                        chopped_ranges.push_back(path_range);
-                        continue;
-                    }
-                    // now find outlier clusters based on stdev and mean
-                    // extract a minimum viable repeat length
-                    // scan across the step vector, looking for where the repeat region begins and ends
-                    // cut at the repeat boundaries
-
-                    // Q: should we determine the repeat length for each sequence or all?
-                    // each is simple, but maybe expensive
-                    // all could provide higher precision, but it's muddier
-
-                    // if this doesn't work, we're going to blindly cut anyway
-                    uint64_t last_cut = 0;
-                    step_handle_t last_end = path_range.begin;
-                    //path_range_t* new_range = nullptr;
-                    uint64_t pos = 0;
-                    step_handle_t step;
-                    for (step = path_range.begin;
+                    // steps in id space
+                    std::string seq;
+                    std::string name = graph.get_path_name(graph.get_path_handle_of_step(path_range.begin));
+                    for (step_handle_t step = path_range.begin;
                          step != path_range.end;
                          step = graph.get_next_step(step)) {
-                        //handle_t h = graph.get_handle_of_step(step);
-                        //uint64_t id = graph.get_id(h);
-                        //int64_t node_pos = vec_graph.node_vector_offset(id);
-                        pos += graph.get_length(graph.get_handle_of_step(step));
-                        if (pos - last_cut > cut_length) {
-                            step_handle_t next = graph.get_next_step(step);
-                            chopped_ranges.push_back({last_end, next, pos - last_cut});
-                            last_end = next;
-                            last_cut = pos;
-                        }
+                        seq.append(graph.get_sequence(graph.get_handle_of_step(step)));
                     }
-                    if (step != last_end) {
-                        chopped_ranges.push_back({last_end, step, pos - last_cut});
+                    if (seq.length() < 2*min_copy_length) continue;
+                    //std::cerr << "on " << name << "\t" << seq.length() << std::endl;
+                    std::vector<uint8_t> vec(seq.begin(), seq.end());
+                    sautocorr::repeat_t result = sautocorr::repeat(vec,
+                                                                   min_copy_length,
+                                                                   max_copy_length,
+                                                                   min_copy_length,
+                                                                   min_autocorr_z,
+                                                                   autocorr_stride);
+                    repeats.push_back(result);
+                }
+                // if there is, set the cut length to some fraction of it
+                std::vector<double> lengths;
+                double max_z = 0;
+                for (auto& repeat : repeats) {
+                    if (repeat.length > 0) {
+                        lengths.push_back(repeat.length);
+                        max_z = std::max(repeat.z_score, max_z);
                     }
                 }
-                block.path_ranges = chopped_ranges;
-                // order the path ranges from longest/shortest to shortest/longest
-                ips4o::parallel::sort(
+                found_repeat = !lengths.empty();
+                if (found_repeat) {
+                    double repeat_length = sautocorr::vec_mean(lengths.begin(), lengths.end());
+                    cut_length = std::round(repeat_length / 2.0);
+                    ++n_repeat_blocks;
+                    //std::cerr << "found repeat of " << repeat_length << " and Z-score " << max_z << " cutting to " << cut_length << std::endl;
+                } else {
+                    // if not, chop blindly
+                    cut_length = max_poa_length;
+                }
+            }
+            std::vector<path_range_t> chopped_ranges;
+            for (auto& path_range : block.path_ranges) {
+
+                if (!found_repeat && path_range.length < cut_length) {
+                    chopped_ranges.push_back(path_range);
+                    continue;
+                }
+                // now find outlier clusters based on stdev and mean
+                // extract a minimum viable repeat length
+                // scan across the step vector, looking for where the repeat region begins and ends
+                // cut at the repeat boundaries
+
+                // Q: should we determine the repeat length for each sequence or all?
+                // each is simple, but maybe expensive
+                // all could provide higher precision, but it's muddier
+
+                // if this doesn't work, we're going to blindly cut anyway
+                uint64_t last_cut = 0;
+                step_handle_t last_end = path_range.begin;
+                //path_range_t* new_range = nullptr;
+                uint64_t pos = 0;
+                step_handle_t step;
+                for (step = path_range.begin;
+                     step != path_range.end;
+                     step = graph.get_next_step(step)) {
+                    //handle_t h = graph.get_handle_of_step(step);
+                    //uint64_t id = graph.get_id(h);
+                    //int64_t node_pos = vec_graph.node_vector_offset(id);
+                    pos += graph.get_length(graph.get_handle_of_step(step));
+                    if (pos - last_cut > cut_length) {
+                        step_handle_t next = graph.get_next_step(step);
+                        chopped_ranges.push_back({last_end, next, pos - last_cut});
+                        last_end = next;
+                        last_cut = pos;
+                    }
+                }
+                if (step != last_end) {
+                    chopped_ranges.push_back({last_end, step, pos - last_cut});
+                }
+            }
+            block.path_ranges = chopped_ranges;
+            // order the path ranges from longest/shortest to shortest/longest
+            ips4o::parallel::sort(
                     block.path_ranges.begin(), block.path_ranges.end(),
                     order_paths_from_longest
                     ?
@@ -146,20 +146,20 @@ void break_blocks(const xg::XG& graph,
                        const path_range_t& b) {
                         return a.length < b.length;
                     }
-                    );
-                //block.broken = true;
-                //block.is_repeat = found_repeat;
-                breaks_progress.increment(1);
+            );
+            //block.broken = true;
+            //block.is_repeat = found_repeat;
+            breaks_progress.increment(1);
+        }
+        // prepare the path_ranges_t for a consensus graph if necessary
+        // we do this here, because it works in parallel
+        if (consensus_graph) {
+            for (auto& path_range : block.path_ranges) {
+                path_range.nuc_begin = graph.get_position_of_step(path_range.begin);
+                path_range.nuc_end = graph.get_position_of_step(path_range.end);
             }
-            // prepare the path_ranges_t for a consensus graph if necessary
-            // we do this here, because it works in parallel
-            if (consensus_graph) {
-                for (auto& path_range : block.path_ranges) {
-                    path_range.nuc_begin = graph.get_position_of_step(path_range.begin);
-                    path_range.nuc_end = graph.get_position_of_step(path_range.end);
-                }
-            }
-        });
+        }
+    }
     breaks_progress.finish();
     std::cerr << "[smoothxg::break_blocks] cut " << n_cut_blocks << " blocks of which " << n_repeat_blocks << " had repeats" << std::endl;
 
@@ -169,7 +169,6 @@ void break_blocks(const xg::XG& graph,
 
     std::atomic<uint64_t> split_blocks;
     split_blocks.store(0);
-    std::mutex new_blocks_mutex;
 
     auto* broken_blockset = new smoothxg::blockset_t("blocks.broken");
 
@@ -186,130 +185,111 @@ void break_blocks(const xg::XG& graph,
             if (block_was_broken.test(old_block_id)) {
                 for (auto &block : broken_blocks[old_block_id]) {
                     broken_blockset->add_block(new_block_id++, block);
+
+                    std::vector<path_range_t>().swap(block.path_ranges);
                 }
 
                 std::vector<block_t>().swap(broken_blocks[old_block_id]);
                 ++old_block_id;
+            } else {
+                std::this_thread::sleep_for(std::chrono::nanoseconds(1));
             }
         }
     };
     std::thread write_broken_blocks_lambda_thread(write_broken_blocks_lambda);
 
-    //std::vector<std::pair<double, block_t>> new_blocks;
-    paryfor::parallel_for<uint64_t>(
-        0, blockset->size(), thread_count,
-        [&](uint64_t block_id, int tid) {
-            //for (auto& block : blocks) {
-            auto block = blockset->get_block(block_id);
-            // ensure that the sequences in the block
-            // are within our identity threshold
-            // if not, peel them off into splits
-            std::vector<std::string> seqs;
-            for (auto& path_range : block.path_ranges) {
-                std::string name = graph.get_path_name(graph.get_path_handle_of_step(path_range.begin));
-                seqs.emplace_back();
-                auto& seq = seqs.back();
-                for (step_handle_t step = path_range.begin;
-                     step != path_range.end;
-                     step = graph.get_next_step(step)) {
-                    seq.append(graph.get_sequence(graph.get_handle_of_step(step)));
-                }
+#pragma omp parallel for schedule(static,1) num_threads(thread_count)
+    for (uint64_t block_id = 0; block_id < blockset->size(); ++block_id){
+        //for (auto& block : blocks) {
+        auto block = blockset->get_block(block_id);
+        // ensure that the sequences in the block
+        // are within our identity threshold
+        // if not, peel them off into splits
+        std::vector<std::string> seqs;
+        for (auto& path_range : block.path_ranges) {
+            std::string name = graph.get_path_name(graph.get_path_handle_of_step(path_range.begin));
+            seqs.emplace_back();
+            auto& seq = seqs.back();
+            for (step_handle_t step = path_range.begin;
+                 step != path_range.end;
+                 step = graph.get_next_step(step)) {
+                seq.append(graph.get_sequence(graph.get_handle_of_step(step)));
             }
-            std::vector<std::vector<uint64_t>> groups;
-            // iterate through the seqs
-            // for each sequence try to match it to a group at the given identity threshold
-            // if we can't get it to match, add a new group
-            groups.push_back({0}); // seed with the first sequence
-            for (uint64_t i = 1; i < seqs.size(); ++i) {
-                if (block_group_identity == 0) {
-                    groups[0].push_back(i);
-                    continue;
-                }
-                auto& curr_fwd = seqs[i];
-                auto curr_rev = odgi::reverse_complement(curr_fwd);
-                uint64_t best_group = 0;
-                double best_id = -1;
-                for (auto& curr : { curr_fwd, curr_rev }) {
-                    for (uint64_t j = 0; j < groups.size(); ++j) {
-                        auto& group = groups[j];
-                        for (uint64_t k = 0; k < group.size(); ++k) {
-                            auto& other = seqs[group[k]];
-                            EdlibAlignResult result = edlibAlign(curr.c_str(), curr.size(), other.c_str(), other.size(),
-                                                                 edlibNewAlignConfig(-1, EDLIB_MODE_NW, EDLIB_TASK_DISTANCE, NULL, 0));
-                            if (result.status == EDLIB_STATUS_OK
-                                && result.editDistance >= 0) {
-                                double id = (double)(curr.size() - result.editDistance) / (double)(curr.size());
-                                if (id >= block_group_identity && id > best_id) {
-                                    best_group = j;
-                                    best_id = id;
-                                }
+        }
+        std::vector<std::vector<uint64_t>> groups;
+        // iterate through the seqs
+        // for each sequence try to match it to a group at the given identity threshold
+        // if we can't get it to match, add a new group
+        groups.push_back({0}); // seed with the first sequence
+        for (uint64_t i = 1; i < seqs.size(); ++i) {
+            if (block_group_identity == 0) {
+                groups[0].push_back(i);
+                continue;
+            }
+            auto& curr_fwd = seqs[i];
+            auto curr_rev = odgi::reverse_complement(curr_fwd);
+            uint64_t best_group = 0;
+            double best_id = -1;
+            for (auto& curr : { curr_fwd, curr_rev }) {
+                for (uint64_t j = 0; j < groups.size(); ++j) {
+                    auto& group = groups[j];
+                    for (uint64_t k = 0; k < group.size(); ++k) {
+                        auto& other = seqs[group[k]];
+                        EdlibAlignResult result = edlibAlign(curr.c_str(), curr.size(), other.c_str(), other.size(),
+                                                             edlibNewAlignConfig(-1, EDLIB_MODE_NW, EDLIB_TASK_DISTANCE, NULL, 0));
+                        if (result.status == EDLIB_STATUS_OK
+                            && result.editDistance >= 0) {
+                            double id = (double)(curr.size() - result.editDistance) / (double)(curr.size());
+                            if (id >= block_group_identity && id > best_id) {
+                                best_group = j;
+                                best_id = id;
                             }
-                            edlibFreeAlignResult(result);
                         }
+                        edlibFreeAlignResult(result);
                     }
                 }
-                if (best_id > 0) {
-                    groups[best_group].push_back(i);
-                } else {
-                    groups.push_back({i});
-                }
             }
-            if (groups.size() == 1) {
-                // nothing to do
-                //{
-                //    std::lock_guard<std::mutex> guard(new_blocks_mutex);
-                //    new_blocks.push_back(std::make_pair(block_id, block));
-                //}
-
-                broken_blocks[block_id].push_back(block);
+            if (best_id > 0) {
+                groups[best_group].push_back(i);
             } else {
-                ++split_blocks;
-                //uint64_t i = 0;
-
-                for (auto& group : groups) {
-                    block_t new_block;
-                    //new_block.is_split = true;
-                    /*
-                    std::cerr << "group " << i << " contains ";
-                    for (auto& j : group) std::cerr << " " << j;
-                    std::cerr << std::endl;
-                    */
-                    for (auto& j : group) {
-                        new_block.path_ranges.push_back(block.path_ranges[j]);
-                    }
-                    //for (auto& path_range : new_block.path_ranges) {
-                    //    //new_block.total_path_length += path_range.length;
-                    //    //new_block.max_path_length = std::max(new_block.max_path_length, path_range.length);
-                    //}
-                    //{
-                    //    std::lock_guard<std::mutex> guard(new_blocks_mutex);
-                    //    new_blocks.push_back(std::make_pair(block_id + i++ * (1.0/groups.size()), new_block));
-                    //}
-
-                    broken_blocks[block_id].push_back(new_block);
-                }
+                groups.push_back({i});
             }
+        }
+        if (groups.size() == 1) {
+            // nothing to do
+            broken_blocks[block_id].push_back(block);
+        } else {
+            ++split_blocks;
 
-            block_was_broken.set(block_id);
-            splits_progress.increment(1);
-        });
+            for (auto& group : groups) {
+                block_t new_block;
+                //new_block.is_split = true;
+                /*
+                std::cerr << "group " << i << " contains ";
+                for (auto& j : group) std::cerr << " " << j;
+                std::cerr << std::endl;
+                */
+                for (auto& j : group) {
+                    new_block.path_ranges.push_back(block.path_ranges[j]);
+                }
+                //for (auto& path_range : new_block.path_ranges) {
+                //    //new_block.total_path_length += path_range.length;
+                //    //new_block.max_path_length = std::max(new_block.max_path_length, path_range.length);
+                //}
+                //{
+
+                broken_blocks[block_id].push_back(new_block);
+            }
+        }
+
+        block_was_broken.set(block_id);
+        splits_progress.increment(1);
+    };
     splits_progress.finish();
 
     write_broken_blocks_lambda_thread.join();
 
-    std::vector<std::vector<block_t>>().swap(broken_blocks); // clear blocks
-
-    //std::vector<block_t>().swap(blocks); // clear blocks
-    //ips4o::parallel::sort(
-    //    new_blocks.begin(), new_blocks.end(),
-    //    [](const std::pair<double, block_t>& a,
-    //       const std::pair<double, block_t>& b) {
-    //        return a.first < b.first;
-    //    });
-    //for (auto& p : new_blocks) {
-    //    blocks.push_back(p.second);
-    //}
-    //std::vector<std::pair<double, block_t>>().swap(new_blocks); // clear new_blocks
+    std::vector<std::vector<block_t>>().swap(broken_blocks);
 
     delete blockset;
     blockset = broken_blockset;

--- a/src/breaks.cpp
+++ b/src/breaks.cpp
@@ -146,8 +146,8 @@ void break_blocks(const xg::XG& graph,
                         return a.length < b.length;
                     }
                     );
-                block.broken = true;
-                block.is_repeat = found_repeat;
+                //block.broken = true;
+                //block.is_repeat = found_repeat;
                 breaks_progress.increment(1);
             }
             // prepare the path_ranges_t for a consensus graph if necessary
@@ -248,10 +248,10 @@ void break_blocks(const xg::XG& graph,
                     for (auto& j : group) {
                         new_block.path_ranges.push_back(block.path_ranges[j]);
                     }
-                    for (auto& path_range : new_block.path_ranges) {
-                        new_block.total_path_length += path_range.length;
-                        //new_block.max_path_length = std::max(new_block.max_path_length, path_range.length);
-                    }
+                    //for (auto& path_range : new_block.path_ranges) {
+                    //    //new_block.total_path_length += path_range.length;
+                    //    //new_block.max_path_length = std::max(new_block.max_path_length, path_range.length);
+                    //}
                     {
                         std::lock_guard<std::mutex> guard(new_blocks_mutex);
                         new_blocks.push_back(std::make_pair(block_id + i++ * (1.0/groups.size()), new_block));

--- a/src/breaks.cpp
+++ b/src/breaks.cpp
@@ -280,7 +280,6 @@ void break_blocks(const xg::XG& graph,
                 //    //new_block.total_path_length += path_range.length;
                 //    //new_block.max_path_length = std::max(new_block.max_path_length, path_range.length);
                 //}
-                //{
 
                 ready_blocks[block_id].push_back(new_block);
             }

--- a/src/breaks.cpp
+++ b/src/breaks.cpp
@@ -250,8 +250,7 @@ void break_blocks(const xg::XG& graph,
                     }
                     for (auto& path_range : new_block.path_ranges) {
                         new_block.total_path_length += path_range.length;
-                        new_block.max_path_length = std::max(new_block.max_path_length,
-                                                             path_range.length);
+                        //new_block.max_path_length = std::max(new_block.max_path_length, path_range.length);
                     }
                     {
                         std::lock_guard<std::mutex> guard(new_blocks_mutex);

--- a/src/breaks.hpp
+++ b/src/breaks.hpp
@@ -23,7 +23,7 @@ using namespace handlegraph;
 // break the path ranges at likely VNTR boundaries
 // and break the path ranges to be shorter than our "max" sequence size input to spoa
 void break_blocks(const xg::XG& graph,
-                  std::vector<block_t>& blocks,
+                  blockset_t*& blockset,
                   const double& block_group_identity,
                   const uint64_t& max_poa_length,
                   const uint64_t& min_copy_length,

--- a/src/breaks.hpp
+++ b/src/breaks.hpp
@@ -33,6 +33,7 @@ void break_blocks(const xg::XG& graph,
                   const bool& order_paths_from_longest,
                   const bool& break_repeats,
                   const uint64_t& thread_count,
-                  const bool& consensus_graph);
+                  const bool& consensus_graph,
+                  const bool& write_block_to_split_fastas);
 
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -209,7 +209,9 @@ int main(int argc, char** argv) {
         }
     }
 
-    auto blocks = smoothxg::smoothable_blocks(graph,
+    smoothxg::blockset_t blockset;
+    smoothxg::smoothable_blocks(graph,
+                                              blockset,
                                               max_block_weight,
                                               max_block_jump,
                                               min_subpath,
@@ -218,7 +220,8 @@ int main(int argc, char** argv) {
 
     uint64_t min_autocorr_z = 5;
     uint64_t autocorr_stride = 50;
-    smoothxg::break_blocks(graph,
+    //todo
+    /*smoothxg::break_blocks(graph,
                            blocks,
                            block_group_identity,
                            max_poa_length,
@@ -229,7 +232,7 @@ int main(int argc, char** argv) {
                            order_paths_from_longest,
                            true,
                            n_threads,
-                           write_consensus_graph);
+                           write_consensus_graph);*/
 
     // build the path_step_rank_ranges -> index_in_blocks_vector
     // flat_hash_map using SKA: KEY: path_name, VALUE: sorted interval_tree using cgranges https://github.com/lh3/cgranges:
@@ -284,7 +287,7 @@ int main(int argc, char** argv) {
     std::vector<std::string> consensus_path_names;
     {
         auto smoothed = smoothxg::smooth_and_lace(graph,
-                                                  blocks,
+                                                  blockset,
                                                   poa_m,
                                                   poa_n,
                                                   poa_g,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -41,7 +41,9 @@ int main(int argc, char** argv) {
     args::Flag _preserve_unmerged_consensus(parser, "bool", "do not delete original consensus sequences in the merged MAF blocks and in the smoothed graph",{'N', "preserve-unmerged-consensus"});
     args::ValueFlag<double> _contiguous_path_jaccard(parser, "float","minimum fraction of paths that have to be contiguous for merging MAF blocks and consensus sequences (default: 1.0)",{'J', "contiguous-path-jaccard"});
 
-    args::Flag write_block_fastas(parser, "bool", "write the FASTA sequences for blocks as they are processed",{'B', "write-block-fastas"});
+    args::Flag write_block_to_split_fastas(parser, "bool", "write the FASTA sequences for blocks before its splitting",{'A', "write-block-before-split-fastas"});
+    args::Flag write_block_fastas(parser, "bool", "write the FASTA sequences for blocks put into poa",{'B', "write-block-fastas"});
+
     args::ValueFlag<std::string> base(parser, "BASE", "use this basename for temporary files during build", {'b', "base"});
     args::Flag no_prep(parser, "bool", "do not prepare the graph for processing (prep is equivalent to odgi chop followed by odgi sort -p sYgs, and is disabled when taking XG input)", {'n', "no-prep"});
     args::ValueFlag<uint64_t> _max_block_weight(parser, "N", "maximum seed sequence in block [default: 10000]", {'w', "block-weight-max"});
@@ -233,7 +235,8 @@ int main(int argc, char** argv) {
                            order_paths_from_longest,
                            true,
                            n_threads,
-                           write_consensus_graph);
+                           write_consensus_graph,
+                           args::get(write_block_to_split_fastas));
 
     // build the path_step_rank_ranges -> index_in_blocks_vector
     // flat_hash_map using SKA: KEY: path_name, VALUE: sorted interval_tree using cgranges https://github.com/lh3/cgranges:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -41,7 +41,7 @@ int main(int argc, char** argv) {
     args::Flag _preserve_unmerged_consensus(parser, "bool", "do not delete original consensus sequences in the merged MAF blocks and in the smoothed graph",{'N', "preserve-unmerged-consensus"});
     args::ValueFlag<double> _contiguous_path_jaccard(parser, "float","minimum fraction of paths that have to be contiguous for merging MAF blocks and consensus sequences (default: 1.0)",{'J', "contiguous-path-jaccard"});
 
-    args::Flag write_block_to_split_fastas(parser, "bool", "write the FASTA sequences for split blocks",{'A', "write-split-blocks-fastas"});
+    args::Flag write_block_to_split_fastas(parser, "bool", "write the FASTA sequences for split blocks",{'A', "write-split-block-fastas"});
     args::Flag write_block_fastas(parser, "bool", "write the FASTA sequences for blocks put into poa",{'B', "write-poa-block-fastas"});
 
     args::ValueFlag<std::string> base(parser, "BASE", "use this basename for temporary files during build", {'b', "base"});

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -209,20 +209,21 @@ int main(int argc, char** argv) {
         }
     }
 
-    smoothxg::blockset_t blockset;
+    auto* blockset = new smoothxg::blockset_t("blocks");
     smoothxg::smoothable_blocks(graph,
-                                              blockset,
-                                              max_block_weight,
-                                              max_block_jump,
-                                              min_subpath,
-                                              max_edge_jump,
-                                              order_paths_from_longest);
+                              *blockset,
+                              max_block_weight,
+                              max_block_jump,
+                              min_subpath,
+                              max_edge_jump,
+                              order_paths_from_longest,
+                              num_threads);
 
     uint64_t min_autocorr_z = 5;
     uint64_t autocorr_stride = 50;
-    //todo
-    /*smoothxg::break_blocks(graph,
-                           blocks,
+
+    smoothxg::break_blocks(graph,
+                           blockset,
                            block_group_identity,
                            max_poa_length,
                            min_copy_length,
@@ -232,7 +233,7 @@ int main(int argc, char** argv) {
                            order_paths_from_longest,
                            true,
                            n_threads,
-                           write_consensus_graph);*/
+                           write_consensus_graph);
 
     // build the path_step_rank_ranges -> index_in_blocks_vector
     // flat_hash_map using SKA: KEY: path_name, VALUE: sorted interval_tree using cgranges https://github.com/lh3/cgranges:
@@ -287,7 +288,7 @@ int main(int argc, char** argv) {
     std::vector<std::string> consensus_path_names;
     {
         auto smoothed = smoothxg::smooth_and_lace(graph,
-                                                  blockset,
+                                                  *blockset,
                                                   poa_m,
                                                   poa_n,
                                                   poa_g,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -271,7 +271,7 @@ int main(int argc, char** argv) {
         maf_header += (order_paths_from_longest ? "longest" : "shortest");
         maf_header += "\n";
 
-        // break_blocks parameters
+        // create_blocks
         maf_header += "# max_block_weight=" + std::to_string(max_block_weight) +
                 " max_block_jump=" + std::to_string(max_block_jump) +
                 " min_subpath=" + std::to_string(min_subpath) +
@@ -282,7 +282,8 @@ int main(int argc, char** argv) {
                 " min_copy_length=" + std::to_string(min_copy_length) +
                 " max_copy_length=" + std::to_string(max_copy_length) +
                 " min_autocorr_z=" + std::to_string(min_autocorr_z) +
-                " autocorr_stride=" + std::to_string(autocorr_stride) + "\n";
+                " autocorr_stride=" + std::to_string(autocorr_stride) +
+                " block_group_identity=" + std::to_string(block_group_identity) + "\n";
     }
 
     std::vector<std::string> consensus_path_names;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -41,8 +41,8 @@ int main(int argc, char** argv) {
     args::Flag _preserve_unmerged_consensus(parser, "bool", "do not delete original consensus sequences in the merged MAF blocks and in the smoothed graph",{'N', "preserve-unmerged-consensus"});
     args::ValueFlag<double> _contiguous_path_jaccard(parser, "float","minimum fraction of paths that have to be contiguous for merging MAF blocks and consensus sequences (default: 1.0)",{'J', "contiguous-path-jaccard"});
 
-    args::Flag write_block_to_split_fastas(parser, "bool", "write the FASTA sequences for blocks before its splitting",{'A', "write-block-before-split-fastas"});
-    args::Flag write_block_fastas(parser, "bool", "write the FASTA sequences for blocks put into poa",{'B', "write-block-fastas"});
+    args::Flag write_block_to_split_fastas(parser, "bool", "write the FASTA sequences for split blocks",{'A', "write-split-blocks-fastas"});
+    args::Flag write_block_fastas(parser, "bool", "write the FASTA sequences for blocks put into poa",{'B', "write-poa-block-fastas"});
 
     args::ValueFlag<std::string> base(parser, "BASE", "use this basename for temporary files during build", {'b', "base"});
     args::Flag no_prep(parser, "bool", "do not prepare the graph for processing (prep is equivalent to odgi chop followed by odgi sort -p sYgs, and is disabled when taking XG input)", {'n', "no-prep"});

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -289,7 +289,7 @@ int main(int argc, char** argv) {
     std::vector<std::string> consensus_path_names;
     {
         auto smoothed = smoothxg::smooth_and_lace(graph,
-                                                  *blockset,
+                                                  blockset,
                                                   poa_m,
                                                   poa_n,
                                                   poa_g,

--- a/src/smooth.cpp
+++ b/src/smooth.cpp
@@ -73,8 +73,10 @@ void write_fasta_for_block(const xg::XG &graph,
                            const block_t &block,
                            const uint64_t &block_id,
                            const std::vector<std::string>& seqs,
-                           const std::vector<std::string>& names) {
-    std::string s = "smoothxg_block_" + std::to_string(block_id) + ".fa";
+                           const std::vector<std::string>& names,
+                           const std::string& prefix,
+                           const std::string& suffix) {
+    std::string s = prefix + std::to_string(block_id) + suffix + ".fa";
     std::ofstream fasta(s.c_str());
     for (uint64_t i = 0; i < seqs.size(); ++i) {
         fasta << ">" << names[i] << " " << seqs[i].size() << std::endl
@@ -111,7 +113,7 @@ odgi::graph_t smooth_abpoa(const xg::XG &graph, const block_t &block, const uint
 
     //#ifdef SMOOTH_WRITE_BLOCKS_FASTA
     if (save_block_fastas) {
-        write_fasta_for_block(graph, block, block_id, seqs, names);
+        write_fasta_for_block(graph, block, block_id, seqs, names, "smoothxg_");
     }
 //#endif
 
@@ -387,7 +389,7 @@ odgi::graph_t smooth_spoa(const xg::XG &graph, const block_t &block,
     }
 
     if (save_block_fastas) {
-        write_fasta_for_block(graph, block, block_id, seqs, names);
+        write_fasta_for_block(graph, block, block_id, seqs, names, "smoothxg_");
     }
 
     /*

--- a/src/smooth.cpp
+++ b/src/smooth.cpp
@@ -113,7 +113,7 @@ odgi::graph_t smooth_abpoa(const xg::XG &graph, const block_t &block, const uint
 
     //#ifdef SMOOTH_WRITE_BLOCKS_FASTA
     if (save_block_fastas) {
-        write_fasta_for_block(graph, block, block_id, seqs, names, "smoothxg_");
+        write_fasta_for_block(graph, block, block_id, seqs, names, "smoothxg_into_abpoa");
     }
 //#endif
 
@@ -389,7 +389,7 @@ odgi::graph_t smooth_spoa(const xg::XG &graph, const block_t &block,
     }
 
     if (save_block_fastas) {
-        write_fasta_for_block(graph, block, block_id, seqs, names, "smoothxg_");
+        write_fasta_for_block(graph, block, block_id, seqs, names, "smoothxg_into_spoa");
     }
 
     /*

--- a/src/smooth.cpp
+++ b/src/smooth.cpp
@@ -672,7 +672,7 @@ void _put_block_in_group(
 }
 
 odgi::graph_t smooth_and_lace(const xg::XG &graph,
-                              blockset_t &blockset,
+                              const blockset_t &blockset,
                               int poa_m, int poa_n,
                               int poa_g, int poa_e,
                               int poa_q, int poa_c,
@@ -698,8 +698,6 @@ odgi::graph_t smooth_and_lace(const xg::XG &graph,
 
     IITree<uint64_t, uint64_t> merged_block_id_intervals_tree;
     std::unordered_set<uint64_t> inverted_merged_block_id_intervals_ranks;
-
-    blockset.index(n_threads, blockset.size() - 1);
 
     {
         bool produce_maf = !path_output_maf.empty();

--- a/src/smooth.cpp
+++ b/src/smooth.cpp
@@ -1089,7 +1089,7 @@ odgi::graph_t smooth_and_lace(const xg::XG &graph,
                 consensus_name = consensus_base_name + std::to_string(block_id);
             }
 
-            // std::cerr << "on block " << block_id+1 << " of " << blocks.size() << std::endl;
+            // std::cerr << "on block " << block_id+1 << " of " << blockset.size() << std::endl;
             auto &block_graph = block_graphs[block_id];
 
             if (use_abpoa) {

--- a/src/smooth.cpp
+++ b/src/smooth.cpp
@@ -672,7 +672,7 @@ void _put_block_in_group(
 }
 
 odgi::graph_t smooth_and_lace(const xg::XG &graph,
-                              const std::vector<block_t> &blocks,
+                              blockset_t &blockset,
                               int poa_m, int poa_n,
                               int poa_g, int poa_e,
                               int poa_q, int poa_c,
@@ -691,13 +691,15 @@ odgi::graph_t smooth_and_lace(const xg::XG &graph,
     // record the start and end points of all the path ranges and the consensus
     //
     std::vector<odgi::graph_t> block_graphs;
-    block_graphs.resize(blocks.size());
+    block_graphs.resize(blockset.size());
 
     std::vector<path_position_range_t> path_mapping;
     std::vector<path_position_range_t> consensus_mapping;
 
     IITree<uint64_t, uint64_t> merged_block_id_intervals_tree;
     std::unordered_set<uint64_t> inverted_merged_block_id_intervals_ranks;
+
+    blockset.index(n_threads, blockset.size() - 1);
 
     {
         bool produce_maf = !path_output_maf.empty();
@@ -707,8 +709,8 @@ odgi::graph_t smooth_and_lace(const xg::XG &graph,
 
         // If merged consensus sequences have to be embedded, this structures are needed to keep the blocks' coordinates,
         // but the sequences will be considered (and kept in memory) only if a MAF has to be produced
-        std::vector<std::vector<maf_row_t>> mafs(produce_maf || (add_consensus && merge_blocks) ? blocks.size() : 0);
-        atomicbitvector::atomic_bv_t mafs_ready(produce_maf || (add_consensus && merge_blocks) ? blocks.size() : 0);
+        std::vector<std::vector<maf_row_t>> mafs(produce_maf || (add_consensus && merge_blocks) ? blockset.size() : 0);
+        atomicbitvector::atomic_bv_t mafs_ready(produce_maf || (add_consensus && merge_blocks) ? blockset.size() : 0);
 
         auto write_maf_lambda = [&]() {
             if (produce_maf || (add_consensus && merge_blocks)) {
@@ -716,7 +718,7 @@ odgi::graph_t smooth_and_lace(const xg::XG &graph,
 
                 maf_t merged_maf_blocks;
 
-                uint64_t num_blocks = blocks.size();
+                uint64_t num_blocks = blockset.size();
 
                 std::ofstream out_maf;
 
@@ -1028,7 +1030,7 @@ odgi::graph_t smooth_and_lace(const xg::XG &graph,
                                 if (produce_maf) {
                                     bool contains_loops = false;
                                     std::unordered_set<path_handle_t> seen_paths;
-                                    for (auto &path_range : blocks[block_id].path_ranges) {
+                                    for (auto &path_range : blockset.get_block(block_id).path_ranges) {
                                         path_handle_t path = graph.get_path_handle_of_step(path_range.begin);
                                         if (seen_paths.count(path)) {
                                             contains_loops = true;
@@ -1076,13 +1078,13 @@ odgi::graph_t smooth_and_lace(const xg::XG &graph,
         poa_banner << "[smoothxg::smooth_and_lace] applying "
                    << (local_alignment ? "local" : "global") << " "
                    << (use_abpoa ? "abPOA" : "SPOA")
-                   << " to " << blocks.size() << " blocks:";
-        progress_meter::ProgressMeter poa_progress(blocks.size(), poa_banner.str());
+                   << " to " << blockset.size() << " blocks:";
+        progress_meter::ProgressMeter poa_progress(blockset.size(), poa_banner.str());
 
 #pragma omp parallel for schedule(dynamic,1)
-        for (uint64_t i = 0; i < blocks.size(); ++i) {
+        for (uint64_t i = 0; i < blockset.size(); ++i) {
             uint64_t block_id = i;
-            auto &block = blocks[block_id];
+            auto block = blockset.get_block(block_id);
 
             std::string consensus_name;
             if (add_consensus){
@@ -1394,7 +1396,7 @@ odgi::graph_t smooth_and_lace(const xg::XG &graph,
         std::cerr << "[smoothxg::smooth_and_lace] embedding consensus" << std::endl;
 
         // all raw consensus paths
-        std::vector<path_handle_t> consensus_paths(blocks.size());
+        std::vector<path_handle_t> consensus_paths(blockset.size());
         //consensus_paths_by_block
 
         merged_block_id_intervals_tree.index();
@@ -1444,7 +1446,7 @@ odgi::graph_t smooth_and_lace(const xg::XG &graph,
         std::vector<path_handle_t> merged_consensus_paths;
 
         std::vector<size_t> merged_block_id_intervals;
-        merged_block_id_intervals_tree.overlap(0, blocks.size(), merged_block_id_intervals);
+        merged_block_id_intervals_tree.overlap(0, blockset.size(), merged_block_id_intervals);
 
         for (auto &merged_block_id_interval_idx : merged_block_id_intervals){
             uint64_t start = merged_block_id_intervals_tree.start(merged_block_id_interval_idx);

--- a/src/smooth.hpp
+++ b/src/smooth.hpp
@@ -57,7 +57,7 @@ odgi::graph_t smooth_spoa(const xg::XG &graph, const block_t &block,
                           bool save_block_fastas = false);
 
 odgi::graph_t smooth_and_lace(const xg::XG &graph,
-                              blockset_t &blocks,
+                              const blockset_t &blockset,
                               int poa_m, int poa_n,
                               int poa_g, int poa_e,
                               int poa_q, int poa_c,

--- a/src/smooth.hpp
+++ b/src/smooth.hpp
@@ -57,7 +57,7 @@ odgi::graph_t smooth_spoa(const xg::XG &graph, const block_t &block,
                           bool save_block_fastas = false);
 
 odgi::graph_t smooth_and_lace(const xg::XG &graph,
-                              const blockset_t &blockset,
+                              blockset_t*& blockset,
                               int poa_m, int poa_n,
                               int poa_g, int poa_e,
                               int poa_q, int poa_c,

--- a/src/smooth.hpp
+++ b/src/smooth.hpp
@@ -32,11 +32,13 @@ struct path_position_range_t {
     uint64_t target_graph_id;  // the block graph id
 };
 
-void write_tsv_for_block(const xg::XG &graph,
+void write_fasta_for_block(const xg::XG &graph,
                          const block_t &block,
                          const uint64_t &block_id,
                          const std::vector<std::string>& seqs,
-                         const std::vector<std::string>& names);
+                         const std::vector<std::string>& names,
+                         const std::string& prefix,
+                         const std::string& suffix = "");
 
 odgi::graph_t smooth_abpoa(const xg::XG &graph, const block_t &block, const uint64_t &block_id,
                            int poa_m, int poa_n, int poa_g,

--- a/src/smooth.hpp
+++ b/src/smooth.hpp
@@ -57,7 +57,7 @@ odgi::graph_t smooth_spoa(const xg::XG &graph, const block_t &block,
                           bool save_block_fastas = false);
 
 odgi::graph_t smooth_and_lace(const xg::XG &graph,
-                              const std::vector<block_t> &blocks,
+                              blockset_t &blocks,
                               int poa_m, int poa_n,
                               int poa_g, int poa_e,
                               int poa_q, int poa_c,


### PR DESCRIPTION
This introduces several changes to minimize the memory consumption by removing unused fields, using a bitvector during the blocks' preparation, and to avoid storing information (vectors) neeeded only during specific steps before the POA phase. Refactoring the code, the blocks' preparation should be slighlty faster too.

Moreover, now the blocks are read/written on/from disk, exploiting a memory-mapped multimap, and avoiding to keep everything in memory.

**Yeast dataset (`-w 100` to have much more blocks, 759398 in particular)**
```
odgi stats -i Sc+Sp.pan.fpal10k.Y.G50.og -S

#length	nodes	edges	paths
19830938	4712138	6513053	192
```

```
.../master/smoothxg -g Sc+Sp.pan.fpal10k.Y.G50.gfa -o smooth.gfa -t 16 -I 0 -n -w 100

Elapsed (wall clock) time (h:mm:ss or m:ss): 7:29.46
Maximum resident set size (kbytes): 14844372
```

```
.../branch/smoothxg -g Sc+Sp.pan.fpal10k.Y.G50.gfa -o smooth.gfa -t 16 -I 0 -n -w 100

Elapsed (wall clock) time (h:mm:ss or m:ss): 7:27.54
Maximum resident set size (kbytes): 14155180
```

In this case we save ~670 MB of memory.