### PR TITLE
simplify the block structure, saving 16 byte for each path_range

### DIFF
--- a/src/blocks.cpp
+++ b/src/blocks.cpp
@@ -70,7 +70,7 @@ void smoothable_blocks(
             std::vector<path_range_t> path_ranges;
             for (auto& step : traversals) {
                 if (path_ranges.empty()) {
-                    path_ranges.push_back({step, step, 0, 0, 0});
+                    path_ranges.push_back({step, step, 0});
                 } else {
                     auto& path_range = path_ranges.back();
                     auto& last = path_range.end;
@@ -79,7 +79,7 @@ void smoothable_blocks(
                             - (graph.get_position_of_step(last) + graph.get_length(graph.get_handle_of_step(last)))
                             > max_path_jump)) {
                         // make a new range
-                        path_ranges.push_back({step, step, 0, 0, 0});
+                        path_ranges.push_back({step, step, 0});
                     } else {
                         // extend the range
                         last = step;

--- a/src/blocks.hpp
+++ b/src/blocks.hpp
@@ -25,8 +25,6 @@ struct path_range_t {
     step_handle_t begin = { 0, 0 };
     step_handle_t end = { 0, 0 };
     uint64_t length = 0;
-    uint64_t nuc_begin = 0;
-    uint64_t nuc_end = 0;
 };
 
 struct block_t {
@@ -54,8 +52,6 @@ struct ranked_path_range_t {
         path_range.begin = pr.path_range.begin;
         path_range.end = pr.path_range.end;
         path_range.length = pr.path_range.length;
-        path_range.nuc_begin = pr.path_range.nuc_begin;
-        path_range.nuc_end = pr.path_range.nuc_end;
 
         rank = pr.rank;
 

--- a/src/breaks.cpp
+++ b/src/breaks.cpp
@@ -225,14 +225,6 @@ namespace smoothxg {
                 //block.broken = true;
                 //block.is_repeat = found_repeat;
             }
-            // prepare the path_ranges_t for a consensus graph if necessary
-            // we do this here, because it works in parallel
-            if (consensus_graph) {
-                for (auto& path_range : block.path_ranges) {
-                    path_range.nuc_begin = graph.get_position_of_step(path_range.begin);
-                    path_range.nuc_end = graph.get_position_of_step(path_range.end);
-                }
-            }
 
             // Splitting
             // ensure that the sequences in the block are within our identity threshold


### PR DESCRIPTION
In this way, the blocks take up ~23% less space on disk (and memory), as expected.

**cerevisiae.pan.fa.gz.pggb-s50000-p90-n5-a70-K16-k71-w30000-j5000-e5000.sY.G30.gfa**
```
-rw-rw-r-- 1 guarracino guarracino  17M gen 12 19:02 blocks.broken.temp_master
-rw-rw-r-- 1 guarracino guarracino  13M gen 12 19:02 blocks.broken.temp_branch
```

**Sc+Sp.pan.fpal10k.Y.G50.gfa**
```
-rw-rw-r-- 1 guarracino guarracino 307M gen 12 19:07 blocks.broken.temp_master
-rw-rw-r-- 1 guarracino guarracino 239M gen 12 19:05 blocks.broken.temp_branch
```