### PR TITLE
refactoring abPOA integration (and cleaning the SPOA one)

### DIFF
--- a/src/smooth.cpp
+++ b/src/smooth.cpp
@@ -152,11 +152,6 @@ odgi::graph_t* smooth_abpoa(const xg::XG &graph, const block_t &block, const uin
     // finalize parameters
     abpoa_post_set_para(abpt);
 
-    std::vector<char *> seqs_;
-    // transform so that we have an interface between C++ and C
-    std::transform(seqs.begin(), seqs.end(), std::back_inserter(seqs_),
-                   [](const std::string& s) { return (char*)s.c_str();});
-
     // collect sequence length, transform ACGT to 0123
     int n_seqs = seqs.size();
     int *seq_lens = (int *)malloc(sizeof(int) * n_seqs);
@@ -165,8 +160,7 @@ odgi::graph_t* smooth_abpoa(const xg::XG &graph, const block_t &block, const uin
         seq_lens[i] = seqs[i].size();
         bseqs[i] = (uint8_t *)malloc(sizeof(uint8_t) * seq_lens[i]);
         for (int j = 0; j < seq_lens[i]; ++j) {
-            bseqs[i][j] =
-                nst_nt4_table[(int)seqs_[i][j]]; // TODO we make a c_str for every char in the string
+            bseqs[i][j] = nst_nt4_table[(int)seqs[i][j]];
         }
     }
 

--- a/src/smooth.cpp
+++ b/src/smooth.cpp
@@ -1596,53 +1596,54 @@ void build_odgi_abPOA(abpoa_t *ab, abpoa_para_t *abpt, odgi::graph_t* output,
         in_degree[i] = abg->node[i].in_edge_n;
     for (i = 0; i < seq_n; ++i)
         read_paths[i] = (int *)_err_malloc(abg->node_n * sizeof(int));
+
     kdq_int_t *q = kdq_init_int();
 
     // Breadth-First-Search
-    kdq_push_int(q, ABPOA_SRC_NODE_ID);
+    for (i = 0; i < abg->node[ABPOA_SRC_NODE_ID].out_edge_n; ++i) {
+        out_id = abg->node[ABPOA_SRC_NODE_ID].out_id[i];
+        if (--in_degree[out_id] == 0) {
+            kdq_push_int(q, out_id);
+        }
+    }
     while ((id = kdq_shift_int(q)) != 0) {
         cur_id = *id;
-        if (cur_id == ABPOA_SINK_NODE_ID) {
-            kdq_destroy_int(q);
-            break;
-        } else {
-            if (cur_id != ABPOA_SRC_NODE_ID) {
-                // output node
-                // fprintf(stdout, "S\t%d\t%c\n", cur_id - 1,
-                // "ACGTN"[abg->node[cur_id].base]); add node to output graph
-                std::string seq = std::string(
-                    1, static_cast<char>("ACGTN"[abg->node[cur_id].base]));
-                // std::cerr << "seq: " << seq << std::endl;
-                output->create_handle(seq, cur_id - 1);
-                // std::cerr << "cur_id: " << (cur_id - 1) << std::endl;
-                // output all links based pre_ids
-                for (i = 0; i < abg->node[cur_id].in_edge_n; ++i) {
-                    pre_id = abg->node[cur_id].in_id[i];
-                    if (pre_id != ABPOA_SRC_NODE_ID) {
-                        // output edge
-                        // fprintf(stdout, "L\t%d\t+\t%d\t+\t0M\n", pre_id - 1,
-                        // cur_id - 1); std::cerr << "cur_id edge: " << (cur_id
-                        // - 1) << std::endl; std::cerr << "pre_id edge: " <<
-                        // (pre_id - 1) << std::endl;
-                        output->create_edge(output->get_handle(pre_id - 1),
-                                           output->get_handle(cur_id - 1));
-                    }
-                }
-                // add node id to read path
-                int b, read_id;
-                uint64_t num, tmp;
-                b = 0;
-                for (i = 0; i < abg->node[cur_id].read_ids_n; ++i) {
-                    num = abg->node[cur_id].read_ids[i];
-                    while (num) {
-                        tmp = num & -num;
-                        read_id = ilog2_64(abpt, tmp);
-                        read_paths[b+read_id][read_path_i[b+read_id]++] = cur_id - 1;
-                        num ^= tmp;
-                    }
-                    b += 64;
+        if (cur_id != ABPOA_SINK_NODE_ID) {
+            // output node
+            // fprintf(stdout, "S\t%d\t%c\n", cur_id - 1,
+            // "ACGTN"[abg->node[cur_id].base]); add node to output graph
+            std::string seq = std::string(1, "ACGTN"[abg->node[cur_id].base]);
+            // std::cerr << "seq: " << seq << std::endl;
+            output->create_handle(seq, cur_id - 1);
+            // std::cerr << "cur_id: " << (cur_id - 1) << std::endl;
+            // output all links based pre_ids
+            for (i = 0; i < abg->node[cur_id].in_edge_n; ++i) {
+                pre_id = abg->node[cur_id].in_id[i];
+                if (pre_id != ABPOA_SRC_NODE_ID) {
+                    // output edge
+                    // fprintf(stdout, "L\t%d\t+\t%d\t+\t0M\n", pre_id - 1,
+                    // cur_id - 1); std::cerr << "cur_id edge: " << (cur_id
+                    // - 1) << std::endl; std::cerr << "pre_id edge: " <<
+                    // (pre_id - 1) << std::endl;
+                    output->create_edge(output->get_handle(pre_id - 1),
+                                        output->get_handle(cur_id - 1));
                 }
             }
+            // add node id to read path
+            int b, read_id;
+            uint64_t num, tmp;
+            b = 0;
+            for (i = 0; i < abg->node[cur_id].read_ids_n; ++i) {
+                num = abg->node[cur_id].read_ids[i];
+                while (num) {
+                    tmp = num & -num;
+                    read_id = ilog2_64(abpt, tmp);
+                    read_paths[b+read_id][read_path_i[b+read_id]++] = cur_id - 1;
+                    num ^= tmp;
+                }
+                b += 64;
+            }
+
             for (i = 0; i < abg->node[cur_id].out_edge_n; ++i) {
                 out_id = abg->node[cur_id].out_id[i];
                 if (--in_degree[out_id] == 0) {
@@ -1651,9 +1652,9 @@ void build_odgi_abPOA(abpoa_t *ab, abpoa_para_t *abpt, odgi::graph_t* output,
             }
         }
     }
+    kdq_destroy_int(q);
 
     // output read paths
-
     for (i = 0; i < seq_n; ++i) {
         path_handle_t p;
         std::vector<handle_t> steps;

--- a/src/smooth.cpp
+++ b/src/smooth.cpp
@@ -1614,19 +1614,19 @@ void build_odgi_abPOA(abpoa_t *ab, abpoa_para_t *abpt, odgi::graph_t* output,
             // "ACGTN"[abg->node[cur_id].base]); add node to output graph
             std::string seq = std::string(1, "ACGTN"[abg->node[cur_id].base]);
             // std::cerr << "seq: " << seq << std::endl;
-            output->create_handle(seq, cur_id - 1);
+            output->create_handle(seq, cur_id);
             // std::cerr << "cur_id: " << (cur_id - 1) << std::endl;
             // output all links based pre_ids
             for (i = 0; i < abg->node[cur_id].in_edge_n; ++i) {
                 pre_id = abg->node[cur_id].in_id[i];
                 if (pre_id != ABPOA_SRC_NODE_ID) {
                     // output edge
-                    // fprintf(stdout, "L\t%d\t+\t%d\t+\t0M\n", pre_id - 1,
-                    // cur_id - 1); std::cerr << "cur_id edge: " << (cur_id
-                    // - 1) << std::endl; std::cerr << "pre_id edge: " <<
-                    // (pre_id - 1) << std::endl;
-                    output->create_edge(output->get_handle(pre_id - 1),
-                                        output->get_handle(cur_id - 1));
+                    // fprintf(stdout, "L\t%d\t+\t%d\t+\t0M\n", pre_id,
+                    // cur_id); std::cerr << "cur_id edge: " << (cur_id)
+                    // << std::endl; std::cerr << "pre_id edge: " <<
+                    // pre_id << std::endl;
+                    output->create_edge(output->get_handle(pre_id),
+                                        output->get_handle(cur_id));
                 }
             }
             // add node id to read path
@@ -1638,7 +1638,7 @@ void build_odgi_abPOA(abpoa_t *ab, abpoa_para_t *abpt, odgi::graph_t* output,
                 while (num) {
                     tmp = num & -num;
                     read_id = ilog2_64(abpt, tmp);
-                    read_paths[b+read_id][read_path_i[b+read_id]++] = cur_id - 1;
+                    read_paths[b+read_id][read_path_i[b+read_id]++] = cur_id;
                     num ^= tmp;
                 }
                 b += 64;
@@ -1700,14 +1700,14 @@ void build_odgi_abPOA(abpoa_t *ab, abpoa_para_t *abpt, odgi::graph_t* output,
         // we already did that!
         // abpoa_generate_consensus(ab, abpt, seq_n, NULL, NULL, NULL, NULL,
         // NULL);
-        int id = abg->node[ABPOA_SRC_NODE_ID].max_out_id;
+        int max_out_id = abg->node[ABPOA_SRC_NODE_ID].max_out_id;
         // fprintf(stdout, "P\tConsensus_sequence\t");
         path_handle_t p = output->create_path_handle(consensus_name);
         while (true) {
             // fprintf(stdout, "%d+", id-1);
-            output->append_step(p, output->get_handle(id - 1));
-            id = abg->node[id].max_out_id;
-            if (id == ABPOA_SINK_NODE_ID) {
+            output->append_step(p, output->get_handle(max_out_id));
+            max_out_id = abg->node[max_out_id].max_out_id;
+            if (max_out_id == ABPOA_SINK_NODE_ID) {
                 break;
             }
             /*

--- a/src/smooth.cpp
+++ b/src/smooth.cpp
@@ -363,14 +363,6 @@ odgi::graph_t* smooth_spoa(const xg::XG &graph, const block_t &block,
                           const std::string &consensus_name,
                           bool save_block_fastas) {
 
-    std::uint8_t spoa_algorithm = local_alignment ? 0 : 1;
-    std::unique_ptr<spoa::AlignmentEngine> alignment_engine
-        = spoa::createAlignmentEngine(
-            static_cast<spoa::AlignmentType>(spoa_algorithm),
-            poa_m, poa_n, poa_g, poa_e, poa_q, poa_c);
-
-    auto poa_graph = spoa::createGraph();
-
     // collect sequences
     std::vector<std::string> seqs;
     std::vector<std::string> names;
@@ -413,6 +405,15 @@ odgi::graph_t* smooth_spoa(const xg::XG &graph, const block_t &block,
     if (max_sequence_size == 0) {
         return output_graph;
     }
+
+    std::uint8_t spoa_algorithm = local_alignment ? 0 : 1;
+    std::unique_ptr<spoa::AlignmentEngine> alignment_engine
+            = spoa::createAlignmentEngine(
+                    static_cast<spoa::AlignmentType>(spoa_algorithm),
+                    poa_m, poa_n, poa_g, poa_e, poa_q, poa_c);
+
+    auto poa_graph = spoa::createGraph();
+
     // preallocation does not seem to help, and it consumes a lot of memory
     // relative to progressive allocation
     // alignment_engine->prealloc(max_sequence_size, 4);

--- a/src/smooth.cpp
+++ b/src/smooth.cpp
@@ -1745,12 +1745,6 @@ void build_odgi(std::unique_ptr<spoa::Graph> &graph, odgi::graph_t* output,
                 const std::string &consensus_name, bool include_consensus) {
 
     auto &nodes = graph->nodes();
-    std::vector<std::int32_t> in_consensus(nodes.size(), -1);
-    std::int32_t rank = 0;
-    auto consensus = graph->consensus();
-    for (const auto &id : consensus) {
-        in_consensus[id] = rank++;
-    }
 
     for (std::uint32_t i = 0; i < nodes.size(); ++i) {
         std::string seq =

--- a/src/smooth.cpp
+++ b/src/smooth.cpp
@@ -115,16 +115,12 @@ odgi::graph_t* smooth_abpoa(const xg::XG &graph, const block_t &block, const uin
         max_sequence_size = std::max(max_sequence_size, seq.size());
     }
 
-    //#ifdef SMOOTH_WRITE_BLOCKS_FASTA
     if (save_block_fastas) {
         write_fasta_for_block(graph, block, block_id, seqs, names, "smoothxg_into_abpoa");
     }
-//#endif
 
-    // set up POA
-    // done...
-    // run POA
     auto* output_graph = new odgi::graph_t();
+
     // if the graph would be empty, bail out
     if (max_sequence_size == 0) {
         return output_graph;
@@ -164,7 +160,7 @@ odgi::graph_t* smooth_abpoa(const xg::XG &graph, const block_t &block, const uin
     // collect sequence length, transform ACGT to 0123
     int n_seqs = seqs.size();
     int *seq_lens = (int *)malloc(sizeof(int) * n_seqs);
-    uint8_t **bseqs = (uint8_t **)malloc(sizeof(uint8_t *) * n_seqs);
+    auto **bseqs = (uint8_t **)malloc(sizeof(uint8_t *) * n_seqs);
     for (int i = 0; i < n_seqs; ++i) {
         seq_lens[i] = seqs[i].size();
         bseqs[i] = (uint8_t *)malloc(sizeof(uint8_t) * seq_lens[i]);
@@ -175,17 +171,18 @@ odgi::graph_t* smooth_abpoa(const xg::XG &graph, const block_t &block, const uin
     }
 
     // variables to store result
-    uint8_t **cons_seq; int **cons_cov, *cons_l, cons_n=0;
-    uint8_t **msa_seq; int msa_l=0;
+    uint8_t **cons_seq; int **cons_cov, *cons_l, cons_n = 0;
+    uint8_t **msa_seq; int msa_l = 0;
 
     int i, tot_n = n_seqs;
-    uint8_t *is_rc = (uint8_t *)_err_malloc(n_seqs * sizeof(uint8_t));
+    auto *is_rc = (uint8_t *)_err_malloc(n_seqs * sizeof(uint8_t));
+
     abpoa_reset_graph(ab, abpt, seq_lens[0]);
 
     std::vector<bool> aln_is_reverse;
     for (i = 0; i < n_seqs; ++i) {
         abpoa_res_t res;
-        res.graph_cigar = 0, res.n_cigar = 0, res.is_rc = 0;
+        res.graph_cigar = nullptr, res.n_cigar = 0, res.is_rc = 0;
         res.traceback_ok = 1;
         abpt->rev_cigar = 0;
         bool aligned = -1 != abpoa_align_sequence_to_graph(ab, abpt, bseqs[i], seq_lens[i], &res);
@@ -203,7 +200,7 @@ odgi::graph_t* smooth_abpoa(const xg::XG &graph, const block_t &block, const uin
     }
 
     if (maf != nullptr){
-        abpoa_generate_rc_msa(ab, abpt, NULL, is_rc, tot_n, NULL, &msa_seq, &msa_l);
+        abpoa_generate_rc_msa(ab, abpt, nullptr, is_rc, tot_n, NULL, &msa_seq, &msa_l);
     }
 
    /*fprintf(stdout, ">Multiple_sequence_alignment\n");
@@ -387,20 +384,8 @@ odgi::graph_t* smooth_spoa(const xg::XG &graph, const block_t &block,
         write_fasta_for_block(graph, block, block_id, seqs, names, "smoothxg_into_spoa");
     }
 
-    /*
-    std::string s = "smoothxg_block_" + std::to_string(block_id) + ".fa";
-    std::ofstream fasta(s.c_str());
-    for (uint64_t i = 0; i < seqs.size(); ++i) {
-        fasta << ">" << names[i] << " " << seqs[i].size() << std::endl
-              << seqs[i] << std::endl;
-    }
-    fasta.close();
-    */
-
-    // set up POA
-    // done...
-    // run POA
     auto* output_graph = new odgi::graph_t();
+
     // if the graph would be empty, bail out
     if (max_sequence_size == 0) {
         return output_graph;

--- a/src/smooth.cpp
+++ b/src/smooth.cpp
@@ -98,6 +98,7 @@ odgi::graph_t* smooth_abpoa(const xg::XG &graph, const block_t &block, const uin
     // collect sequences
     std::vector<std::string> seqs;
     std::vector<std::string> names;
+    std::size_t max_sequence_size = 0;
     for (auto &path_range : block.path_ranges) {
         seqs.emplace_back();
         auto &seq = seqs.back();
@@ -110,6 +111,8 @@ odgi::graph_t* smooth_abpoa(const xg::XG &graph, const block_t &block, const uin
                       graph.get_path_handle_of_step(path_range.begin))
                << "_" << graph.get_position_of_step(path_range.begin);
         names.push_back(namess.str());
+
+        max_sequence_size = std::max(max_sequence_size, seq.size());
     }
 
     //#ifdef SMOOTH_WRITE_BLOCKS_FASTA
@@ -121,11 +124,6 @@ odgi::graph_t* smooth_abpoa(const xg::XG &graph, const block_t &block, const uin
     // set up POA
     // done...
     // run POA
-    std::size_t max_sequence_size = 0;
-    for (auto &seq : seqs) {
-        max_sequence_size = std::max(max_sequence_size, seq.size());
-    }
-
     auto* output_graph = new odgi::graph_t();
     // if the graph would be empty, bail out
     if (max_sequence_size == 0) {
@@ -372,9 +370,11 @@ odgi::graph_t* smooth_spoa(const xg::XG &graph, const block_t &block,
             poa_m, poa_n, poa_g, poa_e, poa_q, poa_c);
 
     auto poa_graph = spoa::createGraph();
+
     // collect sequences
     std::vector<std::string> seqs;
     std::vector<std::string> names;
+    std::size_t max_sequence_size = 0;
     for (auto &path_range : block.path_ranges) {
         seqs.emplace_back();
         auto &seq = seqs.back();
@@ -387,6 +387,8 @@ odgi::graph_t* smooth_spoa(const xg::XG &graph, const block_t &block,
                       graph.get_path_handle_of_step(path_range.begin))
                << "_" << graph.get_position_of_step(path_range.begin);
         names.push_back(namess.str());
+
+        max_sequence_size = std::max(max_sequence_size, seq.size());
     }
 
     if (save_block_fastas) {
@@ -406,10 +408,6 @@ odgi::graph_t* smooth_spoa(const xg::XG &graph, const block_t &block,
     // set up POA
     // done...
     // run POA
-    std::size_t max_sequence_size = 0;
-    for (auto &seq : seqs) {
-        max_sequence_size = std::max(max_sequence_size, seq.size());
-    }
     auto* output_graph = new odgi::graph_t();
     // if the graph would be empty, bail out
     if (max_sequence_size == 0) {

--- a/src/smooth.cpp
+++ b/src/smooth.cpp
@@ -340,7 +340,7 @@ odgi::graph_t* smooth_abpoa(const xg::XG &graph, const block_t &block, const uin
     //auto graph_copy = output_graph;
     if (!odgi::algorithms::unchop(*output_graph)) {
         std::cerr << "[smoothxg::smooth_abpoa] error: unchop failure, saving before/after graph to disk" << std::endl;
-        std::ofstream a("smoothxg_unchop_failure_before.gfa");
+        //std::ofstream a("smoothxg_unchop_failure_before.gfa");
         //graph_copy.to_gfa(a);
         //a.close();
         std::ofstream b("smoothxg_unchop_failure_after.gfa");

--- a/src/smooth.cpp
+++ b/src/smooth.cpp
@@ -1659,14 +1659,11 @@ void build_odgi_abPOA(abpoa_t *ab, abpoa_para_t *abpt, odgi::graph_t* output,
         path_handle_t p;
         std::vector<handle_t> steps;
         std::uint32_t node_id;
-        if (!sequence_names.empty()) {
-            // fprintf(stdout, "P\t%s\t", sequence_names[i]);
-            // std::cerr << "P\t" << sequence_names[i] << "\t";
-            p = output->create_path_handle(sequence_names[i]);
-        } else {
-            // fprintf(stdout, "P\t%d\t", i+1);
-            p = output->create_path_handle(std::to_string(i + 1));
-        }
+
+        // fprintf(stdout, "P\t%s\t", sequence_names[i]);
+        // std::cerr << "P\t" << sequence_names[i] << "\t";
+        p = output->create_path_handle(sequence_names[i]);
+
         if (aln_is_reverse[i]) {
             for (j = read_path_i[i] - 1; j >= 0; --j) {
                 // fprintf(stdout, "%d-", read_paths[i][j]);

--- a/src/smooth.cpp
+++ b/src/smooth.cpp
@@ -1642,9 +1642,7 @@ void build_odgi_abPOA(abpoa_t *ab, abpoa_para_t *abpt, odgi::graph_t* output,
     for (i = 0; i < seq_n; ++i)
         read_paths[i] = (int *)_err_malloc(abg->node_n * sizeof(int));
 
-    // Breadth-First-Search
     std::vector<int> stack_node_ids;
-
     for (i = 0; i < abg->node[ABPOA_SRC_NODE_ID].out_edge_n; ++i) {
         out_id = abg->node[ABPOA_SRC_NODE_ID].out_id[i];
         if (--in_degree[out_id] == 0) {
@@ -1661,7 +1659,7 @@ void build_odgi_abPOA(abpoa_t *ab, abpoa_para_t *abpt, odgi::graph_t* output,
             // "ACGTN"[abg->node[cur_id].base]); add node to output graph
             std::string seq = std::string(1, "ACGTN"[abg->node[cur_id].base]);
             // std::cerr << "seq: " << seq << std::endl;
-            output->create_handle(seq, abg->node_id_to_index[cur_id]);
+            output->create_handle(seq, cur_id);
             // std::cerr << "cur_id: " << cur_id << std::endl;
             // output all links based pre_ids
             for (i = 0; i < abg->node[cur_id].in_edge_n; ++i) {
@@ -1672,8 +1670,7 @@ void build_odgi_abPOA(abpoa_t *ab, abpoa_para_t *abpt, odgi::graph_t* output,
                     // cur_id); std::cerr << "cur_id edge: " << cur_id
                     // << std::endl; std::cerr << "pre_id edge: " <<
                     // pre_id << std::endl;
-                    output->create_edge(output->get_handle(abg->node_id_to_index[pre_id]),
-                                        output->get_handle(abg->node_id_to_index[cur_id]));
+                    output->create_edge(output->get_handle(pre_id), output->get_handle(cur_id));
                 }
             }
             // add node id to read path
@@ -1685,7 +1682,7 @@ void build_odgi_abPOA(abpoa_t *ab, abpoa_para_t *abpt, odgi::graph_t* output,
                 while (num) {
                     tmp = num & -num;
                     read_id = ilog2_64(abpt, tmp);
-                    read_paths[b+read_id][read_path_i[b+read_id]++] = abg->node_id_to_index[cur_id];
+                    read_paths[b+read_id][read_path_i[b+read_id]++] = cur_id;
                     num ^= tmp;
                 }
                 b += 64;
@@ -1710,26 +1707,11 @@ void build_odgi_abPOA(abpoa_t *ab, abpoa_para_t *abpt, odgi::graph_t* output,
             for (j = read_path_i[i] - 1; j >= 0; --j) {
                 // fprintf(stdout, "%d-", read_paths[i][j]);
                 output->append_step(p, output->flip(output->get_handle(read_paths[i][j])));
-                /*
-                if (j != 0) {
-                    fprintf(stdout, ",");
-                } else {
-                    fprintf(stdout, "\t*\n");
-                }
-                 */
             }
         } else {
             for (j = 0; j < read_path_i[i]; ++j) {
                 // fprintf(stdout, "%d+", read_paths[i][j]);
                 output->append_step(p, output->get_handle(read_paths[i][j]));
-                /*
-                if (j != read_path_i[i]-1) {
-                    fprintf(stdout, ",");
-                }
-                else {
-                    fprintf(stdout, "\t*\n");
-                }
-                */
             }
         }
     }
@@ -1741,20 +1723,11 @@ void build_odgi_abPOA(abpoa_t *ab, abpoa_para_t *abpt, odgi::graph_t* output,
 
         while (true) {
             // fprintf(stdout, "%d+", id-1);
-            output->append_step(p, output->get_handle(abg->node_id_to_index[max_out_id]));
+            output->append_step(p, output->get_handle(max_out_id));
             max_out_id = abg->node[max_out_id].max_out_id;
             if (max_out_id == ABPOA_SINK_NODE_ID) {
                 break;
             }
-            /*
-            if (id != ABPOA_SINK_NODE_ID) {
-                fprintf(stdout, ",");
-            }
-            else {
-                // fprintf(stdout, "\t*\n");
-                break;
-            }
-             */
         }
     }
 

--- a/src/smooth.hpp
+++ b/src/smooth.hpp
@@ -83,7 +83,7 @@ void build_odgi(std::unique_ptr<spoa::Graph> &graph, odgi::graph_t* output,
 
 void build_odgi_abPOA(abpoa_t *ab, abpoa_para_t *abpt, odgi::graph_t* output,
                       const std::vector<std::string> &sequence_names,
-                      const std::vector<bool> &aln_is_reverse,
+                      const uint8_t* aln_is_reverse,
                       const std::string &consensus_name,
                       bool include_consensus = true);
 } // namespace smoothxg

--- a/src/smooth.hpp
+++ b/src/smooth.hpp
@@ -39,7 +39,7 @@ void write_fasta_for_block(const xg::XG &graph,
                          const std::string& prefix,
                          const std::string& suffix = "");
 
-odgi::graph_t smooth_abpoa(const xg::XG &graph, const block_t &block, const uint64_t &block_id,
+odgi::graph_t smooth_abpoa(const xg::XG &graph, const block_t &block, uint64_t block_id,
                            int poa_m, int poa_n, int poa_g,
                            int poa_e, int poa_q, int poa_c,
                            bool local_alignment,
@@ -48,8 +48,7 @@ odgi::graph_t smooth_abpoa(const xg::XG &graph, const block_t &block, const uint
                            const std::string &consensus_name = "",
                            bool save_block_fastas = false);
 
-odgi::graph_t smooth_spoa(const xg::XG &graph, const block_t &block,
-                          const uint64_t &block_id,
+odgi::graph_t smooth_spoa(const xg::XG &graph, const block_t &block, uint64_t block_id,
                           std::int8_t poa_m, std::int8_t poa_n, std::int8_t poa_g,
                           std::int8_t poa_e, std::int8_t poa_q, std::int8_t poa_c,
                           bool local_alignment,


### PR DESCRIPTION
This removes unnecessary steps and memory allocations. However, dangerous memory peaks are still observed with abPOA. Going deeper to catch the problem.