### PR TITLE
temporary filenames management for xg and blockset

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -247,6 +247,7 @@ set(CMAKE_BUILD_TYPE Debug)
 #set(CMAKE_BUILD_TYPE Release)
 
 add_library(smoothxg_objs OBJECT
+  src/tempfile.cpp
   src/xg.cpp
   src/chain.cpp
   src/prep.cpp

--- a/src/blocks.hpp
+++ b/src/blocks.hpp
@@ -73,8 +73,8 @@ private:
     std::string _path_tmp_blocks;
 
 public:
-    explicit blockset_t(const std::string& suffix = "") {
-        _path_tmp_blocks = temp_file::create("blockset-") + suffix;
+    explicit blockset_t() {
+        _path_tmp_blocks = temp_file::create("");
 
         _num_blocks = 0;
         _blocks = new mmmulti::map<uint64_t, ranked_path_range_t>(_path_tmp_blocks, {0});

--- a/src/blocks.hpp
+++ b/src/blocks.hpp
@@ -9,9 +9,12 @@
 #include "mmmultimap.hpp"
 #include "xg.hpp"
 
+#include "tempfile.hpp"
+
 namespace smoothxg {
 
 using namespace handlegraph;
+
 
 inline uint64_t path_rank(const step_handle_t& step) {
     return as_integers(step)[0];
@@ -70,13 +73,11 @@ private:
     std::string _path_tmp_blocks;
 
 public:
-    explicit blockset_t(const std::string& dir_work = "") {
-        _path_tmp_blocks = dir_work + ".temp";
-        std::remove(_path_tmp_blocks.c_str());
+    explicit blockset_t(const std::string& suffix = "") {
+        _path_tmp_blocks = temp_file::create("blockset-") + suffix;
 
         _num_blocks = 0;
         _blocks = new mmmulti::map<uint64_t, ranked_path_range_t>(_path_tmp_blocks, {0});
-        //_blocks.set_base_filename(
 
         _blocks->open_writer();
     }
@@ -85,7 +86,7 @@ public:
         //_blocks.close_writer();
         //_blocks.close_reader();
         delete _blocks;
-        std::remove(_path_tmp_blocks.c_str());
+        //std::remove(_path_tmp_blocks.c_str()); // The temp_file are deleted automatically
     }
 
     [[nodiscard]] uint64_t size() const {

--- a/src/blocks.hpp
+++ b/src/blocks.hpp
@@ -74,7 +74,7 @@ private:
 
 public:
     explicit blockset_t() {
-        _path_tmp_blocks = temp_file::create("");
+        _path_tmp_blocks = temp_file::create();
 
         _num_blocks = 0;
         _blocks = new mmmulti::map<uint64_t, ranked_path_range_t>(_path_tmp_blocks, {0});
@@ -86,7 +86,7 @@ public:
         //_blocks.close_writer();
         //_blocks.close_reader();
         delete _blocks;
-        //std::remove(_path_tmp_blocks.c_str()); // The temp_file are deleted automatically
+        //std::remove(_path_tmp_blocks.c_str()); // The temp_file is deleted automatically
     }
 
     [[nodiscard]] uint64_t size() const {

--- a/src/breaks.cpp
+++ b/src/breaks.cpp
@@ -82,7 +82,7 @@ namespace smoothxg {
         atomicbitvector::atomic_bv_t block_is_ready(blockset->size());
         std::vector<std::vector<block_t>> ready_blocks(blockset->size());
 
-        auto *broken_blockset = new smoothxg::blockset_t("blocks.broken");
+        auto *broken_blockset = new smoothxg::blockset_t();
 
         auto write_ready_blocks_lambda = [&]() {
             uint64_t num_blocks = block_is_ready.size();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -267,7 +267,7 @@ int main(int argc, char** argv) {
         }
     }
 
-    auto* blockset = new smoothxg::blockset_t("blocks");
+    auto* blockset = new smoothxg::blockset_t();
     smoothxg::smoothable_blocks(*graph,
                                 *blockset,
                                 max_block_weight,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -260,8 +260,7 @@ int main(int argc, char** argv) {
             gfa_in_name = args::get(gfa_in);
         }
         std::cerr << "[smoothxg::main] building xg index" << std::endl;
-        graph->from_gfa(gfa_in_name, args::get(validate),
-                       args::get(base).empty() ? gfa_in_name : args::get(base));
+        graph->from_gfa(gfa_in_name, args::get(validate), args::get(base));
         if (!args::get(keep_temp) && !args::get(no_prep)) {
             std::remove(gfa_in_name.c_str());
         }

--- a/src/tempfile.cpp
+++ b/src/tempfile.cpp
@@ -1,0 +1,111 @@
+#include <set>
+#include <iostream>
+#include <unistd.h>
+#include "tempfile.hpp"
+
+namespace temp_file {
+
+    // We use this to make the API thread-safe
+    std::recursive_mutex monitor;
+
+    std::string temp_dir;
+
+    /// Because the names are in a static object, we can delete them when
+    /// std::exit() is called.
+    struct Handler {
+        std::set <std::string> filenames;
+        std::string parent_directory;
+
+        ~Handler() {
+            // No need to lock in static destructor
+            for (auto &filename : filenames) {
+                std::remove(filename.c_str());
+            }
+            if (!parent_directory.empty()) {
+                // There may be extraneous files in the directory still (like .fai files)
+                auto directory = opendir(parent_directory.c_str());
+
+                dirent *dp;
+                while ((dp = readdir(directory)) != nullptr) {
+                    // For every item still in it, delete it.
+                    // TODO: Maybe eventually recursively delete?
+                    std::remove((parent_directory + "/" + dp->d_name).c_str());
+                }
+                closedir(directory);
+
+                // Delete the directory itself
+                std::remove(parent_directory.c_str());
+            }
+        }
+    } handler;
+
+    std::string create(const std::string &base) {
+        std::lock_guard <std::recursive_mutex> lock(monitor);
+
+        if (handler.parent_directory.empty()) {
+            // Make a parent directory for our temp files
+            std::string tmpdirname_cpp = get_dir() + "/" + base + "XXXXXX";
+            char *tmpdirname = new char[tmpdirname_cpp.length() + 1];
+            strcpy(tmpdirname, tmpdirname_cpp.c_str());
+            auto got = mkdtemp(tmpdirname);
+            if (got != nullptr) {
+                // Save the directory we got
+                handler.parent_directory = got;
+            } else {
+                std::cerr << "[smoothxg]: couldn't create temp directory: " << tmpdirname << std::endl;
+                exit(1);
+            }
+            delete[] tmpdirname;
+        }
+
+        std::string tmpname = handler.parent_directory + "/" + base + "XXXXXX";
+        // hack to use mkstemp to get us a safe temporary file name
+        int fd = mkstemp(&tmpname[0]);
+        if (fd != -1) {
+            // we don't leave it open; we are assumed to open it again externally
+            close(fd);
+        } else {
+            std::cerr << "[smoothxg]: couldn't create temp file on base "
+                 << base << " : " << tmpname << std::endl;
+            exit(1);
+        }
+        handler.filenames.insert(tmpname);
+        return tmpname;
+    }
+
+    std::string create() {
+        // No need to lock as we call this thing that locks
+        return create("temp-");
+    }
+
+    void remove(const std::string &filename) {
+        std::lock_guard <std::recursive_mutex> lock(monitor);
+
+        std::remove(filename.c_str());
+        handler.filenames.erase(filename);
+    }
+
+    void set_dir(const std::string &new_temp_dir) {
+        std::lock_guard <std::recursive_mutex> lock(monitor);
+
+        temp_dir = new_temp_dir;
+    }
+
+    std::string get_dir() {
+        std::lock_guard <std::recursive_mutex> lock(monitor);
+
+        // Get the default temp dir from environment variables.
+        if (temp_dir.empty()) {
+            const char *system_temp_dir = nullptr;
+            for (const char *var_name : {"TMPDIR", "TMP", "TEMP", "TEMPDIR", "USERPROFILE"}) {
+                if (system_temp_dir == nullptr) {
+                    system_temp_dir = getenv(var_name);
+                }
+            }
+            temp_dir = (system_temp_dir == nullptr ? "/tmp" : system_temp_dir);
+        }
+
+        return temp_dir;
+    }
+
+}

--- a/src/tempfile.cpp
+++ b/src/tempfile.cpp
@@ -52,20 +52,20 @@ namespace temp_file {
                 // Save the directory we got
                 handler.parent_directory = got;
             } else {
-                std::cerr << "[smoothxg]: couldn't create temp directory: " << tmpdirname << std::endl;
+                std::cerr << "[smoothxg::tempfile]: couldn't create temp directory: " << tmpdirname << std::endl;
                 exit(1);
             }
             delete[] tmpdirname;
         }
 
-        std::string tmpname = handler.parent_directory + "/" + base + "XXXXXX";
+        std::string tmpname = handler.parent_directory + "/XXXXXX";
         // hack to use mkstemp to get us a safe temporary file name
         int fd = mkstemp(&tmpname[0]);
         if (fd != -1) {
             // we don't leave it open; we are assumed to open it again externally
             close(fd);
         } else {
-            std::cerr << "[smoothxg]: couldn't create temp file on base "
+            std::cerr << "[smoothxg::tempfile]: couldn't create temp file on base "
                  << base << " : " << tmpname << std::endl;
             exit(1);
         }

--- a/src/tempfile.hpp
+++ b/src/tempfile.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <string>
+#include <mutex>
+#include <cstdio>
+#include <dirent.h>
+
+#include <cstring>
+
+/**
+ * Temporary files. Create with create() and remove with remove(). All
+ * temporary files will be deleted when the program exits normally or with
+ * std::exit(). The files will be created in a directory determined from
+ * environment variables, though this can be overridden with set_dir().
+ * The interface is thread-safe.
+ */
+namespace temp_file {
+
+    /// Create a temporary file starting with the given base name
+    std::string create(const std::string& base);
+
+    /// Create a temporary file
+    std::string create();
+
+    /// Remove a temporary file
+    void remove(const std::string& filename);
+
+    /// Set a temp dir, overriding system defaults and environment variables.
+    void set_dir(const std::string& new_temp_dir);
+
+    /// Get the current temp dir
+    std::string get_dir();
+
+} // namespace temp_file

--- a/src/xg.cpp
+++ b/src/xg.cpp
@@ -281,7 +281,7 @@ void XG::deserialize_members(std::istream& in) {
                     }
                     
                     // create the new node-to-path indexes
-                    index_node_to_path(temp_file::create("xg-"));
+                    index_node_to_path(temp_file::create());
                 }
                 else {
                     // we're in the more recent encoding, so we can load
@@ -798,7 +798,7 @@ void XG::from_enumerators(const std::function<void(const std::function<void(cons
                           bool validate, std::string basename) {
 
     if (basename.empty()) {
-        basename = temp_file::create("xg-");
+        basename = temp_file::create();
     }
     node_count = 0;
     seq_length = 0;

--- a/src/xg.hpp
+++ b/src/xg.hpp
@@ -6,13 +6,11 @@
 #include <queue>
 #include <omp.h>
 #include <unordered_map>
-#include <unordered_set>
 #include <string>
 #include <functional>
 #include <utility>
 #include <tuple>
 #include <sys/types.h>
-#include <dirent.h>
 
 #include <sdsl/bit_vectors.hpp>
 #include <sdsl/enc_vector.hpp>
@@ -31,7 +29,6 @@
 #include <handlegraph/serializable_handle_graph.hpp>
 
 #include <mmmultimap.hpp>
-
 
 namespace xg {
 
@@ -580,32 +577,6 @@ public:
     size_t handle_start(size_t offset) const;
     size_t step_rank_at_position(size_t pos) const;
 };
-
-/**
- * Temporary files. Create with create() and remove with remove(). All
- * temporary files will be deleted when the program exits normally or with
- * std::exit(). The files will be created in a directory determined from
- * environment variables, though this can be overridden with set_dir().
- * The interface is thread-safe.
- */
-namespace temp_file {
-
-/// Create a temporary file starting with the given base name
-std::string create(const std::string& base);
-
-/// Create a temporary file
-std::string create();
-
-/// Remove a temporary file
-void remove(const std::string& filename);
-
-/// Set a temp dir, overriding system defaults and environment variables.
-void set_dir(const std::string& new_temp_dir);
-
-/// Get the current temp dir
-std::string get_dir();
-
-} // namespace temp_file
 
 /// Uses OMP to get the count of threads
 int get_thread_count(void);


### PR DESCRIPTION
This avoid conflicts when multiple instances of smoothxg are run in parallel.