### PR TITLE
removal of the contiguity constraint in merging blocks

### DIFF
--- a/src/maf.hpp
+++ b/src/maf.hpp
@@ -5,15 +5,6 @@
 #include <vector>
 #include <map>
 
-struct maf_row_t {
-    std::string path_name;
-    uint64_t record_start = 0;
-    uint64_t seq_size = 0;
-    bool is_reversed = false;
-    uint64_t path_length = 0;
-    std::string aligned_seq;
-};
-
 struct maf_partial_row_t {
     uint64_t record_start = 0;
     uint64_t seq_size = 0;
@@ -29,18 +20,18 @@ struct maf_t {
 };
 
 template<typename T>
-void clear_vector(std::vector<T>& vec) {
+inline void clear_vector(std::vector<T>& vec) {
     vec.clear();
     vec.shrink_to_fit();
     std::vector<T>().swap(vec);
 }
-void clear_string(std::string& str){
+inline void clear_string(std::string& str){
     str.clear();
     str.shrink_to_fit();
     std::string().swap(str);
 }
 
-void write_maf_rows(std::ofstream &out, const std::map<std::string, std::vector<maf_partial_row_t>>& maf) {
+inline void write_maf_rows(std::ofstream &out, const std::map<std::string, std::vector<maf_partial_row_t>>& maf) {
     // determine output widths for everything
     size_t max_src_length = 0;
     size_t max_start_length = 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -59,7 +59,7 @@ int main(int argc, char** argv) {
     args::ValueFlag<uint64_t> _max_block_jump(parser, "N", "maximum path jump to include in block [default: 5000]", {'j', "path-jump-max"});
     args::ValueFlag<uint64_t> _max_edge_jump(parser, "N", "maximum edge jump before breaking [default: 5000]", {'e', "edge-jump-max"});
 
-    args::ValueFlag<uint64_t> _max_merged_groups_in_memory(parser, "N", "increasing this value, much more blocks that are not immediately contiguous along the graph will be merged [default: 20]", {'G', "max-block-groups-in-memory"});
+    args::ValueFlag<uint64_t> _max_merged_groups_in_memory(parser, "N", "increasing this value, much more blocks that are not immediately contiguous along the graph will be merged [default: 50]", {'G', "max-block-groups-in-memory"});
 
     // Block split
     args::ValueFlag<uint64_t> _min_length_mash_based_clustering(parser, "N", "minimum sequence length to cluster sequences using mash-distance [default: 200, 0 to disable it]", {'L', "min-seq-len-mash"});
@@ -147,7 +147,7 @@ int main(int argc, char** argv) {
     uint64_t max_copy_length = _max_copy_length ? args::get(_max_copy_length) : 20000;
     uint64_t max_poa_length = _max_poa_length ? args::get(_max_poa_length) : 10000;
 
-    uint64_t max_merged_groups_in_memory = _max_merged_groups_in_memory ? args::get(_max_merged_groups_in_memory) : 20;
+    uint64_t max_merged_groups_in_memory = _max_merged_groups_in_memory ? args::get(_max_merged_groups_in_memory) : 50;
 
     // Block split
     uint64_t min_length_mash_based_clustering =  _min_length_mash_based_clustering ? args::get(_min_length_mash_based_clustering) : 200;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -59,6 +59,8 @@ int main(int argc, char** argv) {
     args::ValueFlag<uint64_t> _max_block_jump(parser, "N", "maximum path jump to include in block [default: 5000]", {'j', "path-jump-max"});
     args::ValueFlag<uint64_t> _max_edge_jump(parser, "N", "maximum edge jump before breaking [default: 5000]", {'e', "edge-jump-max"});
 
+    args::ValueFlag<uint64_t> _max_merged_groups_in_memory(parser, "N", "increasing this value, much more blocks that are not immediately contiguous along the graph will be merged [default: 20]", {'G', "max-block-groups-in-memory"});
+
     // Block split
     args::ValueFlag<uint64_t> _min_length_mash_based_clustering(parser, "N", "minimum sequence length to cluster sequences using mash-distance [default: 200, 0 to disable it]", {'L', "min-seq-len-mash"});
     args::ValueFlag<double> _block_group_identity(parser, "N", "minimum edit-based identity to cluster sequences [default: 0.5]", {'I', "block-id-min"});
@@ -144,6 +146,8 @@ int main(int argc, char** argv) {
     uint64_t min_copy_length = _min_copy_length ? args::get(_min_copy_length) : 1000;
     uint64_t max_copy_length = _max_copy_length ? args::get(_max_copy_length) : 20000;
     uint64_t max_poa_length = _max_poa_length ? args::get(_max_poa_length) : 10000;
+
+    uint64_t max_merged_groups_in_memory = _max_merged_groups_in_memory ? args::get(_max_merged_groups_in_memory) : 20;
 
     // Block split
     uint64_t min_length_mash_based_clustering =  _min_length_mash_based_clustering ? args::get(_min_length_mash_based_clustering) : 200;
@@ -347,7 +351,8 @@ int main(int argc, char** argv) {
                                                   !args::get(use_spoa),
                                                   args::get(add_consensus) ? "Consensus_" : "",
                                                   consensus_path_names,
-                                                  args::get(write_block_fastas));
+                                                  args::get(write_block_fastas),
+                                                  max_merged_groups_in_memory);
 
         uint64_t smoothed_nodes = 0;
         uint64_t smoothed_length = 0;

--- a/src/smooth.cpp
+++ b/src/smooth.cpp
@@ -988,7 +988,8 @@ odgi::graph_t* smooth_and_lace(const xg::XG &graph,
                               bool use_abpoa,
                               const std::string &consensus_base_name,
                               std::vector<std::string>& consensus_path_names,
-                              bool write_fasta_blocks) {
+                              bool write_fasta_blocks,
+                              uint64_t max_merged_groups_in_memory) {
 
     bool add_consensus = !consensus_base_name.empty();
 
@@ -1021,7 +1022,6 @@ odgi::graph_t* smooth_and_lace(const xg::XG &graph,
             if (produce_maf || (add_consensus && merge_blocks)) {
                 uint64_t block_id = 0;
 
-                uint8_t MAX_MERGED_GROUPS_IN_MEMORY = 10;
                 std::deque<maf_t> merged_maf_blocks_queue;
 
                 uint64_t num_blocks = blockset->size();
@@ -1211,7 +1211,7 @@ odgi::graph_t* smooth_and_lace(const xg::XG &graph,
                         }
 
                         if (!merged) {
-                            if (merged_maf_blocks_queue.size() >= MAX_MERGED_GROUPS_IN_MEMORY){
+                            if (merged_maf_blocks_queue.size() >= max_merged_groups_in_memory){
                                 // Write the merged group on the left
                                 auto& merged_maf_blocks = merged_maf_blocks_queue.front();
 

--- a/src/smooth.cpp
+++ b/src/smooth.cpp
@@ -1665,17 +1665,27 @@ odgi::graph_t* smooth_and_lace(const xg::XG &graph,
 
         // Create first the path handles
         for (auto &pos_range : consensus_mapping) {
-            // TODO TO FIX
-//            if (!preserve_unmerged_consensus && are_there_merged_intervals){
-//                std::vector<size_t> result;
-//                merged_block_id_intervals_tree.overlap(pos_range.block_id, pos_range.block_id + 1, result);
-//
-//                if (!result.empty()) {
-//                    // Invalidate the position range (it will not be used anymore)
-//                    pos_range.end_pos = pos_range.start_pos;
-//                    continue; // skip the embedding for the single consensus sequence
-//                }
-//            }
+            if (!preserve_unmerged_consensus && are_there_merged_intervals){
+                ///////////////////////////////////////////////////
+                // TODO can we do this search better/faster?
+                bool found = false;
+                for (auto& merged_block_id_intervals_tree : merged_block_id_intervals_tree_vector) {
+                    std::vector<size_t> result;
+                    merged_block_id_intervals_tree.overlap(pos_range.block_id, pos_range.block_id + 1, result);
+
+                    if (!result.empty()) {
+                        found = true;
+                        break;
+                    }
+                }
+                ////////////////////////////////////////////////
+
+                if (found) {
+                    // Invalidate the position range (it will not be used anymore)
+                    pos_range.end_pos = pos_range.start_pos;
+                    continue; // skip the embedding for the single consensus sequence
+                }
+            }
 
             consensus_paths[pos_range.block_id] = smoothed->create_path_handle(
                     block_graphs[pos_range.block_id]->get_path_name(pos_range.target_path)

--- a/src/smooth.hpp
+++ b/src/smooth.hpp
@@ -69,7 +69,8 @@ odgi::graph_t* smooth_and_lace(const xg::XG &graph,
                               bool use_abpoa,
                               const std::string &consensus_name,
                               std::vector<std::string>& consensus_path_names,
-                              bool write_fasta_blocks);
+                              bool write_fasta_blocks,
+                              uint64_t max_merged_groups_in_memory);
 
 void write_gfa(std::unique_ptr<spoa::Graph> &graph, std::ostream &out,
                const std::vector<std::string> &sequence_names,

--- a/src/smooth.hpp
+++ b/src/smooth.hpp
@@ -29,7 +29,7 @@ struct path_position_range_t {
     step_handle_t start_step = { 0, 0 };  // start step in the base graph
     step_handle_t end_step = { 0, 0 };    // end step in the base graph
     path_handle_t target_path = as_path_handle(0); // target path in smoothed block graph
-    uint64_t target_graph_id = 0;  // the block graph id
+    uint64_t block_id = 0;  // the block graph id
 };
 
 void write_fasta_for_block(const xg::XG &graph,


### PR DESCRIPTION
This PR generalizes the block merge, no longer requiring the blocks to be contiguous for merging. This reduces the number of resulting total blocks in the MAF file and the number of total consensus sequences in the smoothed graph. Less, and therefore longer, consensus sequences lead also to more grained consensus graphs, with bigger nodes which are tastier for aligners as GraphAligner.