### PR TITLE
less permissive gap openings during the POA step

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -120,7 +120,7 @@ int main(int argc, char **argv) {
                                               {'l', "poa-length-max"});
     args::ValueFlag<uint64_t> num_threads(parser, "N", "use this many threads during parallel steps", {'t', "threads"});
     args::ValueFlag<std::string> poa_params(parser, "match,mismatch,gap1,ext1(,gap2,ext2)",
-                                            "score parameters for partial order alignment, if 4 then gaps are affine, if 6 then gaps are convex [default: 2,4,4,2,24,1]",
+                                            "score parameters for partial order alignment, if 4 then gaps are affine, if 6 then gaps are convex [default: 2,4,5,2,24,1]",
                                             {'p', "poa-params"});
     args::ValueFlag<int> _prep_node_chop(parser, "N", "during prep, chop nodes to this length [default: 100]",
                                          {'X', "chop-to"});
@@ -248,7 +248,7 @@ int main(int argc, char **argv) {
 
         int poa_m = 2;
         int poa_n = 4;
-        int poa_g = 4;
+        int poa_g = 5;
         int poa_e = 2;
         int poa_q = 24;
         int poa_c = 1;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -120,7 +120,7 @@ int main(int argc, char **argv) {
                                               {'l', "poa-length-max"});
     args::ValueFlag<uint64_t> num_threads(parser, "N", "use this many threads during parallel steps", {'t', "threads"});
     args::ValueFlag<std::string> poa_params(parser, "match,mismatch,gap1,ext1(,gap2,ext2)",
-                                            "score parameters for partial order alignment, if 4 then gaps are affine, if 6 then gaps are convex [default: 2,4,5,2,24,1]",
+                                            "score parameters for partial order alignment, if 4 then gaps are affine, if 6 then gaps are convex [default: 2,4,6,2,24,1]",
                                             {'p', "poa-params"});
     args::ValueFlag<int> _prep_node_chop(parser, "N", "during prep, chop nodes to this length [default: 100]",
                                          {'X', "chop-to"});
@@ -248,7 +248,7 @@ int main(int argc, char **argv) {
 
         int poa_m = 2;
         int poa_n = 4;
-        int poa_g = 5;
+        int poa_g = 6;
         int poa_e = 2;
         int poa_q = 24;
         int poa_c = 1;


### PR DESCRIPTION
The current POA parameters are a bit too permissive in opening gaps, leading to graphs with too many nodes. Increasing the gap opening penalties lead to longer smoothed graphs, but with less nodes. Moreover, this prevents having too many opened gaps which lead to an "indel explosion" when calling variants in the tricky regions.

Unfortunately, this comes with a price, increasing time and memory consumption because the PO graphs tends to be longer.

**[HPRCy1.MHC dataset](https://github.com/pangenome/MHC)**

The current default parameters for abPOA are in the first row.

In the unsmoothed graph, 20726 SNPs and 44584 INDELs are identified with gfautil.

| --poa-params  | smoothed graph length (bp) | smoothed graph nodes | consensus_graphs@1000 nodes | consensus_graphs@1000 length (bp) | time (hh:mm:ss) | memory (kbytes) | SNPs (gfautil) | INDELs (gfautil) | SNPs (vg deconstruct) | INDELs (vg deconstruct) |
| ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- |
| 2,4,4,2,24,1 | 7332530 | 416088 | 7082300 | 1385 | 8:26 | 8417764 | 19278 | 26466 | 37341 | 31193 |
| 2,4,5,2,24,1  | 7331314 | 398496 | 7082859 | 1302 | 10:13 | 9429532 | 19291 | 26385 | - | - |
| 2,4,6,2,24,1  | 7334110 | 364376 | 7093341 | 1325 | 13:15 | 10444224 | 19347 | 26144 | - | - |
| 2,4,8,2,24,1  | 7443796 | 343638 | 7093910 | 1283 | 17:22 | 10594120 | 19306 | 26129 | - | - |
| 2,4,10,2,24,1 | 7331786 | 335663 | 7093881 | 1278 | 20:00 | 10751988 | 19290 | 26023 | - | - |
| 2,4,12,2,24,1  | 7337237 | 331448 | 7094254 | 1322 | 20:36 | 10955188 | 19229 | 25849 | - | - |
| 2,4,6,4,24,2  | 7370239 | 462569 | 7072769 | 1299 | 7:06 | 14085092 | 19899 | 26594 | - | - |
| 2,4,8,4,24,2  | 7373952 | 453177 | 7073511 | 1356 | 7:29 | 15795656 | 19890 | 26480 | - | - |
| 2,4,5,2,25,1  | 7331821 | 399171 | 7083165 | 1328 | 10:30 | 9288312 | 19295 | 26396 | - | - |
| 2,4,6,2,26,1  | 7336349 | 365880 | 7094580 | 1326 | 13:33 | 10190952 | 19322 | 26093 | - | - |
| 1,9,16,2,41,1  | 7396726 | 243475 | 7158720 | 1321 | 23:40 | 15625060 | 18832 | 25562 | - | - |
| 1,6,6,2 26,1  | 7363573 | 270578 | 7111560 | 1289 | 23:05  | 13830640  | 18550 | 25284 | - | - |
| 2,4,6,2,0,0  | 7427042  | 480053  | 7088727 | 1562 | 6:17 | 5068184 | 20546 | 27610 | 40438 | 19809 |
| 2,4,8,2,0,0  | 7443796  | 480610  | 7092089 | 1553 | 6:25 | 5446368 | 20551 | 27292 | 45524 | 26364 |
| SPOA default  | 7270162 | 246117  | 7143242 | 1538 | 2:05:54 | 24856296 | 21584 | 30379 | - | - |