### PR TITLE
obtain split gap compressed identity metric with WFA

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -52,3 +52,6 @@
 [submodule "deps/patchmap"]
 	path = deps/patchmap
 	url = https://github.com/1ykos/patchmap.git
+[submodule "deps/WFA"]
+	path = deps/WFA
+	url = https://github.com/ekg/WFA.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -242,6 +242,7 @@ ExternalProject_Get_property(mkmh SOURCE_DIR)
 set(mkmh_INCLUDE "${SOURCE_DIR}")
 
 add_subdirectory(deps/edlib EXCLUDE_FROM_ALL)
+add_subdirectory(deps/WFA EXCLUDE_FROM_ALL)
 
 set(CMAKE_BUILD_TYPE Debug)
 #set(CMAKE_BUILD_TYPE Release)
@@ -332,6 +333,7 @@ set(smoothxg_INCLUDES
   "${bbhash_INCLUDE}"
   "${mkmh_INCLUDE}"
   "deps/edlib/edlib/include"
+  "deps/WFA"
   "deps/patchmap")
 
 set(smoothxg_LIBS
@@ -342,6 +344,7 @@ set(smoothxg_LIBS
   "${handlegraph_LIB}/libhandlegraph.a"
   "${abPOA_LIB}/libabpoa.a"
   "-latomic"
+  wfa
   )
 
 

--- a/src/breaks.hpp
+++ b/src/breaks.hpp
@@ -9,7 +9,9 @@
 #include <vector>
 #include <numeric>
 #include <cmath>
-#include "edlib.h"
+#include "WFA/edit/edit_cigar.hpp"
+#include "WFA/gap_affine/affine_wavefront_align.hpp"
+#include "WFA/utils/commons.hpp"
 #include "blocks.hpp"
 #include "sautocorr.hpp"
 #include "xg.hpp"


### PR DESCRIPTION
This is more accurate than edlib. Some care may need to be taken to avoid putting very long sequences into the split.