### PR TITLE
use jemalloc

### DIFF
--- a/.github/workflows/small_test_on_push.yml
+++ b/.github/workflows/small_test_on_push.yml
@@ -20,6 +20,7 @@ jobs:
           libgsl-dev
           zlib1g-dev
           libzstd-dev
+          libjemalloc-dev
       - name: Init and update submodules
         run: git submodule update --init --recursive
       - name: Build smoothxg

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -361,7 +361,7 @@ target_link_libraries(smoothxg edlib)
 # https://github.com/yangao07/abPOA/blob/17d7b287b905bcd0e684ca5015a78e5a73a40798/example.c#L3
 find_package(ZLIB)
 #find_package(ZSTD)
-target_link_libraries(smoothxg ZLIB::ZLIB zstd)
+target_link_libraries(smoothxg ZLIB::ZLIB zstd jemalloc)
 
 set_target_properties(smoothxg PROPERTIES OUTPUT_NAME "smoothxg")
 target_include_directories(smoothxg PUBLIC ${smoothxg_INCLUDES})

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Path names should be unique.
 `smoothxg` uses cmake to build itself and its dependencies. At least GCC V10.1 is required for compilation.
 
 ```
-sudo apt-get update && sudo apt-get install -y libatomic-ops-dev libgsl-dev zlib1g-dev libzstd-dev
+sudo apt-get update && sudo apt-get install -y libatomic-ops-dev libgsl-dev zlib1g-dev libzstd-dev libjemalloc-dev
 
 git clone --recursive https://github.com/pangenome/smoothxg.git
 cd smoothxg


### PR DESCRIPTION
This provides a dramatic reduction in memory usage, particularly in the abPOA step, where we experience a lot of memory fragmentation.