### PR TITLE
link consensus parts rather than full paths

### DIFF
--- a/src/consensus_graph.hpp
+++ b/src/consensus_graph.hpp
@@ -17,11 +17,19 @@
 
 namespace smoothxg {
 
+enum path_part_t : uint8_t {
+    begin = 1,
+    middle = 2,
+    end = 3
+};
+
 struct link_path_t {
     std::string* from_cons_name;
     std::string* to_cons_name;
     path_handle_t from_cons_path;
     path_handle_t to_cons_path;
+    path_part_t from_cons_part;
+    path_part_t to_cons_part;
     uint64_t length; // nucleotides
     uint64_t hash;
     step_handle_t begin; // first step off consensus path

--- a/src/consensus_graph.hpp
+++ b/src/consensus_graph.hpp
@@ -17,10 +17,10 @@
 
 namespace smoothxg {
 
-enum path_part_t : uint8_t {
-    begin = 1,
-    middle = 2,
-    end = 3
+enum path_part_t : char {
+    begin = 'b',
+    middle = 'm',
+    end = 'e'
 };
 
 struct link_path_t {


### PR DESCRIPTION
This helps to avoid the introduction of tips into the consensus graph. We collect link paths based on the consensus path end they're on, not the consensus path itself. The first and last 1/8th of each consensus path is considered beginning and end. The rest is the middle.