### PR TITLE
replacing dset64-gccAtomic.hpp with dset64.hpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,8 +8,8 @@ project(smoothxg)
 set(CMAKE_CXX_STANDARD 17)
 
 # Use all standard-compliant optimizations
-set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O3 -mcx16 -g")
-set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -mcx16 -g")
+set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O3 -g")
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -g")
 #set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O3 -mcx16 -g -fsanitize=address")
 #set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -mcx16 -g -fsanitize=address")
 

--- a/src/blocks.cpp
+++ b/src/blocks.cpp
@@ -59,7 +59,7 @@ void smoothable_blocks(
                     }
                 }
             }
-            std::vector<odgi::DisjointSets::Aint> data(nodes.size()+1); // maps into this set of disjoint sets
+            std::vector<std::atomic<odgi::DisjointSets::Aint>> data(nodes.size()+1); // maps into this set of disjoint sets
             auto dset = odgi::DisjointSets(data.data(), data.size());
             for (auto& path_range : block.path_ranges) {
                 step_handle_t step = path_range.begin;

--- a/src/blocks.hpp
+++ b/src/blocks.hpp
@@ -9,7 +9,7 @@
 #include "mmmultimap.hpp"
 #include "xg.hpp"
 #include "flat_hash_map.hpp"
-#include "deps/odgi/src/dset64-gccAtomic.hpp"
+#include "deps/odgi/src/dset64.hpp"
 
 #include "tempfile.hpp"
 


### PR DESCRIPTION
Updating `odgi` so we won't have to use `-mcx16` during compilation anymore.