### PR TITLE
specify conservative seeding parameters

### DIFF
--- a/src/smooth.cpp
+++ b/src/smooth.cpp
@@ -239,6 +239,9 @@ odgi::graph_t* smooth_abpoa(const xg::XG &graph, const block_t &block, const uin
     abpt->gap_ext1 = poa_e;
     abpt->gap_ext2 = poa_c;
     abpt->disable_seeding = 0; // allow seeding (this greatly reduces runtime and memory)
+    abpt->k = 19;
+    abpt->w = 10;
+    abpt->min_w = 3313;
 
     // finalize parameters
     abpoa_post_set_para(abpt);


### PR DESCRIPTION
To avoid alignment errors, we must use large windows (for alignment) during seeded abPOA.