### PR TITLE
Large fixed POA min overlap

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -105,7 +105,7 @@ int main(int argc, char **argv) {
                                                     {'l', "poa-length-target"});
     args::ValueFlag<std::string> _max_poa_length(poa_opts, "N", "maximum sequence length to put into POA, cut sequences over this length (1k = 1K = 1000, 1m = 1M = 10^6, 1g = 1G = 10^9) [default: 2*poa-length-target = 10k]",
                                                  {'q', "poa-length-max"});
-    args::ValueFlag<float> _poa_padding_fraction(poa_opts, "N", "flanking sequence length fraction (padding = average sequence length in the block * N) to pad each end of each sequence with during POA, in effect overlapping and trimming the POA problems [default: 0.01]",
+    args::ValueFlag<float> _poa_padding_fraction(poa_opts, "N", "flanking sequence length fraction (padding = average sequence length in the block * N) to pad each end of each sequence with during POA, in effect overlapping and trimming the POA problems [default: 0.001]",
                                                  {'O', "poa-padding-ratio"});
     args::ValueFlag<std::string> _max_block_depth_for_padding_more(poa_opts, "N",
                                                                    "maximum block depth beyond which a (small) fixed amount of flanking nucleotides is not added (1k = 1K = 1000, 1m = 1M = 10^6, 1g = 1G = 10^9) [default: 1000, 0 to disable it]",
@@ -264,7 +264,7 @@ int main(int argc, char **argv) {
         const uint64_t max_copy_length = _max_copy_length ? (uint64_t)smoothxg::handy_parameter(args::get(_max_copy_length), 20000) : 20000;
         const uint64_t target_poa_length = _target_poa_length ? (uint64_t)smoothxg::handy_parameter(args::get(_target_poa_length), 5000) : 5000;
         const uint64_t max_poa_length = _max_poa_length ? (uint64_t)smoothxg::handy_parameter(args::get(_max_poa_length), 2 * target_poa_length) : 2 * target_poa_length;
-        const float poa_padding_fraction = _poa_padding_fraction ? args::get(_poa_padding_fraction) : (float) 0.01;
+        const float poa_padding_fraction = _poa_padding_fraction ? args::get(_poa_padding_fraction) : (float) 0.001;
         const uint64_t max_block_depth_for_padding_more = _max_block_depth_for_padding_more ?
                 (uint64_t)smoothxg::handy_parameter(args::get(_max_block_depth_for_padding_more), 1000) : 1000;
 

--- a/src/smooth.cpp
+++ b/src/smooth.cpp
@@ -1694,7 +1694,7 @@ odgi::graph_t* smooth_and_lace(const xg::XG &graph,
                 if (block.path_ranges.size() <= max_block_depth_for_padding_more) {
                     // min amount of flanking sequences to add
                     // avoids corner case of padding failure with shallow short blocks
-                    poa_padding = 47;
+                    poa_padding = 311;
                 }
                 // always pad a fraction of our sequence length
                 // note that this can be very short in deep blocks that tend to have many short sequences


### PR DESCRIPTION
This makes sure we have a large fixed overlap, and drops the fractional requirement low.