### PR TITLE
Fix versioning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,9 +140,6 @@ set(sparsepp_INCLUDE ${CMAKE_SOURCE_DIR}/deps/odgi/deps/sparsepp/sparsepp)
 set(flathashmap_INCLUDE ${CMAKE_SOURCE_DIR}/deps/odgi/deps/flat_hash_map)
 set(random_dist_INCLUDE ${CMAKE_SOURCE_DIR}/deps/odgi/deps/cpp_random_distributions)
 
-file(MAKE_DIRECTORY ${CMAKE_SOURCE_DIR}/deps/odgi/include)
-execute_process(COMMAND bash scripts/generate_git_version.sh include WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/deps/odgi)
-
 # mmmulti (memory mapped multimap)
 ExternalProject_Add(mmmulti
   SOURCE_DIR "${CMAKE_SOURCE_DIR}/deps/mmmulti"

--- a/scripts/generate_git_version.sh
+++ b/scripts/generate_git_version.sh
@@ -1,5 +1,9 @@
 INC_DIR=$1
 
+# Go to the directory where the script is
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+cd "$SCRIPT_DIR"
+
 GIT_VERSION=$(git describe --always --tags --long)
 
 echo "#define SMOOTHXG_GIT_VERSION" \"$GIT_VERSION\" > "$INC_DIR"/smoothxg_git_version.hpp


### PR DESCRIPTION
Same as https://github.com/pangenome/odgi/pull/482.

Docker/Singularity images of PGGB display the wrong version of `odgi`. The `odgi` binary is correct, only the version it shows is wrong. In PGGB we use the `odgi` compiled with `smoothxg` and there the script to catch `odgi`'s version wrongly calls `smoothgx`'s git, not `odgi`'s.