### PR TITLE
feat: write/read .og files during intermediate smoothing iterations

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -216,6 +216,7 @@ int main(int argc, char **argv) {
     size_t n_poa_threads = num_poa_threads ? args::get(num_poa_threads) : n_threads;
 
     std::string smoothed_out_gfa = args::get(smoothed_out);
+    std::filesystem::path smoothed_out_gfa_path = smoothed_out_gfa;
     std::vector<std::string> consensus_path_names;
     std::vector<smoothxg::consensus_spec_t> consensus_specs;
     bool requires_consensus = !args::get(vanish_consensus);
@@ -1039,7 +1040,7 @@ int main(int argc, char **argv) {
             std::cerr << smoothxg_iter << "::main] writing smoothed graph to " << path_smoothed_gfa << std::endl;
             ofstream out(path_smoothed_gfa.c_str());
             // can write to gfa on the final iteration
-            if (current_iter == num_iterations - 1) {
+            if (current_iter == num_iterations - 1 && smoothed_out_gfa_path.extension() == ".gfa") {
                 smoothed->to_gfa(out);
             }
             else {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1028,9 +1028,9 @@ int main(int argc, char **argv) {
                         filesystem::path(path_input_gfa).parent_path().string() :
                         args::get(tmp_base);
                 if (patent_dir == "") {
-                    path_smoothed_gfa = prefix + ".smooth." + std::to_string(current_iter) + ".gfa";
+                    path_smoothed_gfa = prefix + ".smooth." + std::to_string(current_iter) + ".og";
                 } else {
-                    path_smoothed_gfa = patent_dir + "/" + prefix + ".smooth." + std::to_string(current_iter) + ".gfa";
+                    path_smoothed_gfa = patent_dir + "/" + prefix + ".smooth." + std::to_string(current_iter) + ".og";
                 }
             } else {
                 path_smoothed_gfa = smoothed_out_gfa;
@@ -1038,7 +1038,13 @@ int main(int argc, char **argv) {
 
             std::cerr << smoothxg_iter << "::main] writing smoothed graph to " << path_smoothed_gfa << std::endl;
             ofstream out(path_smoothed_gfa.c_str());
-            smoothed->to_gfa(out);
+            // can write to gfa on the final iteration
+            if (current_iter == num_iterations - 1) {
+                smoothed->to_gfa(out);
+            }
+            else {
+                smoothed->serialize(out);
+            }
             out.close();
             delete smoothed;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1024,13 +1024,13 @@ int main(int argc, char **argv) {
             std::string path_smoothed_gfa;
             if (current_iter < num_iterations - 1) {
                 consensus_path_names.clear(); // We need this only at the last iteration
-                const std::string patent_dir = args::get(tmp_base).empty() ?
+                const std::string parent_dir = args::get(tmp_base).empty() ?
                         filesystem::path(path_input_gfa).parent_path().string() :
                         args::get(tmp_base);
-                if (patent_dir == "") {
+                if (parent_dir == "") {
                     path_smoothed_gfa = prefix + ".smooth." + std::to_string(current_iter) + ".og";
                 } else {
-                    path_smoothed_gfa = patent_dir + "/" + prefix + ".smooth." + std::to_string(current_iter) + ".og";
+                    path_smoothed_gfa = parent_dir + "/" + prefix + ".smooth." + std::to_string(current_iter) + ".og";
                 }
             } else {
                 path_smoothed_gfa = smoothed_out_gfa;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1106,6 +1106,14 @@ int main(int argc, char **argv) {
             while (std::getline(file, path_name)) {
                 consensus_path_names.push_back(path_name);
             }
+        } else if (filesystem::path(smoothed_out_gfa).extension() == ".og") {
+            // the smoothed graph was serialized as odgi binary; load it that way
+            // (from_gfa would choke on the binary) and build the xg from it.
+            odgi::graph_t g;
+            std::ifstream f(smoothed_out_gfa.c_str());
+            g.deserialize(f);
+            f.close();
+            smoothed_xg.from_path_handle_graph(g);
         } else {
             smoothed_xg.from_gfa(smoothed_out_gfa, false,
                                  args::get(tmp_base).empty() ? smoothed_out_gfa : args::get(tmp_base));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -216,7 +216,6 @@ int main(int argc, char **argv) {
     size_t n_poa_threads = num_poa_threads ? args::get(num_poa_threads) : n_threads;
 
     std::string smoothed_out_gfa = args::get(smoothed_out);
-    std::filesystem::path smoothed_out_gfa_path = smoothed_out_gfa;
     std::vector<std::string> consensus_path_names;
     std::vector<smoothxg::consensus_spec_t> consensus_specs;
     bool requires_consensus = !args::get(vanish_consensus);
@@ -1028,10 +1027,14 @@ int main(int argc, char **argv) {
                 const std::string parent_dir = args::get(tmp_base).empty() ?
                         filesystem::path(path_input_gfa).parent_path().string() :
                         args::get(tmp_base);
+                // The next iteration re-reads this graph: prep loads odgi binary
+                // (.og, fast), but no-prep loads GFA via from_gfa. Emit whichever
+                // format the next iteration's loader can actually read.
+                const std::string ext = args::get(no_prep) ? ".gfa" : ".og";
                 if (parent_dir == "") {
-                    path_smoothed_gfa = prefix + ".smooth." + std::to_string(current_iter) + ".og";
+                    path_smoothed_gfa = prefix + ".smooth." + std::to_string(current_iter) + ext;
                 } else {
-                    path_smoothed_gfa = parent_dir + "/" + prefix + ".smooth." + std::to_string(current_iter) + ".og";
+                    path_smoothed_gfa = parent_dir + "/" + prefix + ".smooth." + std::to_string(current_iter) + ext;
                 }
             } else {
                 path_smoothed_gfa = smoothed_out_gfa;
@@ -1039,12 +1042,12 @@ int main(int argc, char **argv) {
 
             std::cerr << smoothxg_iter << "::main] writing smoothed graph to " << path_smoothed_gfa << std::endl;
             ofstream out(path_smoothed_gfa.c_str());
-            // can write to gfa on the final iteration
-            if (current_iter == num_iterations - 1 && smoothed_out_gfa_path.extension() == ".gfa") {
-                smoothed->to_gfa(out);
-            }
-            else {
+            // Write odgi binary only for an explicit .og target; otherwise GFA.
+            // This keeps the final output GFA unless the user asked for .og.
+            if (filesystem::path(path_smoothed_gfa).extension() == ".og") {
                 smoothed->serialize(out);
+            } else {
+                smoothed->to_gfa(out);
             }
             out.close();
             delete smoothed;

--- a/src/prep.cpp
+++ b/src/prep.cpp
@@ -24,12 +24,12 @@ void prep(
     std::filesystem::path graph_path = gfa_in;
     std::cerr << smoothxg_iter << "::prep] Loading graph for prep " << gfa_in << std::endl;
 
-    if (graph_path.extension() == ".gfa") {
-        odgi::gfa_to_handle(gfa_in, &graph, true, num_threads, true);
-    } else {
-        ifstream f(gfa_in.c_str());
+    if (graph_path.extension() == ".og") {
+        std::ifstream f(gfa_in.c_str());
         graph.deserialize(f);
         f.close();
+    } else {
+        odgi::gfa_to_handle(gfa_in, &graph, true, num_threads, true);
     }
     graph.set_number_of_threads(num_threads);
 
@@ -156,13 +156,9 @@ void prep(
 
     std::cerr << smoothxg_iter << "::prep] writing graph " << gfa_out << std::endl;
 
-    graph_path = gfa_out;
+    // prep output is always re-read as GFA by from_gfa, so write GFA.
     std::ofstream f(gfa_out);
-    if (graph_path.extension() == ".gfa") {
-        graph.to_gfa(f);
-    } else {
-        graph.serialize(f);
-    }
+    graph.to_gfa(f);
     f.close();
 }
 


### PR DESCRIPTION
Even for "mid-sized" graphs (n~25 haplotypes and 100 Mb), the `odgi::gfa_to_handle` step could take up something like ~10% of the entire smoothxg walltime. Presumably this would scale poorly with more haplotypes as path information starts to dominate. Serialising the graph is already implemented and most people probably don't keep intermediate files, so this likely has no external change. Worst case a user can run `odgi view -g -i <graph.og>` to get the gfa version of the intermediate graphs.

~Debatably the output could also be `.og`, since the next step in pggb is to sort the graph with odgi, but that is out of scope for here.~ This was easy enough to just toggle based on the extension of the output file.