### PR TITLE
Fix: use output of previous smoothing iteration as input for next

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -429,7 +429,7 @@ int main(int argc, char **argv) {
                             gfa_in_name = args::get(tmp_base) + '/' + filename + ".prep." + std::to_string(current_iter) + ".gfa";
                         }
                         std::cerr << smoothxg_iter << "::main] prepping graph for smoothing" << std::endl;
-                        smoothxg::prep(args::get(gfa_in), gfa_in_name, node_chop,
+                        smoothxg::prep(path_input_gfa, gfa_in_name, node_chop,
                                     term_updates, true, temp_file::get_dir() + '/', n_threads,
                                     smoothxg_iter);
                     } else {


### PR DESCRIPTION
Should fix #210, where the `smoothxg::prep` would load in the original graph for every iteration, rather than using the output of the previous iteration (the _path_input_gfa_). This only affected graph prep, so the behaviour was likely always correct when `--no-prep`.