### PR TITLE
added checks for apple sillicon and cmake4.0+ version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ build/
 test/
 include
 consensus*
+.idea

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,14 +22,53 @@ if (BUILD_STATIC)
   set(CMAKE_EXE_LINKER_FLAGS "-static")
 endif()
 
-find_package(OpenMP)
-# if(OpenMP_CXX_FOUND)
-#     target_link_libraries(MyTarget PUBLIC OpenMP::OpenMP_CXX)
-# endif()
-
 find_package(PkgConfig REQUIRED)
-find_package(ZLIB REQUIRED)
-# find_package(ZSTD REQUIRED) - needs recent versions of cmake
+
+# --- Start: Logic for using Homebrew ZLIB, ZSTD, and jemalloc on Apple Silicon ---
+set(JEMALLOC_LINK_LIBRARIES "jemalloc")
+set(SMOOTHXG_USE_HOMEBREW_ZLIB_ON_APPLE_SILICON FALSE)
+set(SMOOTHXG_USE_HOMEBREW_ZSTD_ON_APPLE_SILICON FALSE)
+
+if (APPLE AND (CMAKE_SYSTEM_PROCESSOR MATCHES "arm64" OR CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64"))
+  # For pkg_check_modules (pkg-config) to find zlib, you make need to set the following: export PKG_CONFIG_PATH="/opt/homebrew/opt/zstd/lib/pkgconfig:$PKG_CONFIG_PATH"
+  # export PKG_CONFIG_PATH="/opt/homebrew/opt/zlib/lib/pkgconfig:$PKG_CONFIG_PATH"
+  pkg_check_modules(HOMEBREW_ZLIB QUIET zlib)
+  if (HOMEBREW_ZLIB_FOUND)
+    set(SMOOTHXG_USE_HOMEBREW_ZLIB_ON_APPLE_SILICON TRUE)
+    message(STATUS "Apple Silicon: Found Homebrew zlib. Will use it.")
+    message(STATUS "  Homebrew zlib Includes: ${HOMEBREW_ZLIB_INCLUDE_DIRS}")
+    message(STATUS "  Homebrew zlib Link Libraries: ${HOMEBREW_ZLIB_LINK_LIBRARIES}")
+  else()
+    message(FATAL_ERROR "zlib not found")
+  endif ()
+
+  # For pkg_check_modules (pkg-config) to find zstd, you make need to set the following: export PKG_CONFIG_PATH="/opt/homebrew/opt/zstd/lib/pkgconfig:$PKG_CONFIG_PATH"
+  # export PKG_CONFIG_PATH="/opt/homebrew/opt/zstd/lib/pkgconfig:$PKG_CONFIG_PATH"
+  pkg_check_modules(HOMEBREW_ZSTD QUIET libzstd)
+  if (HOMEBREW_ZSTD_FOUND)
+    set(SMOOTHXG_USE_HOMEBREW_ZSTD_ON_APPLE_SILICON TRUE)
+    message(STATUS "Apple Silicon: Found Homebrew ZSTD. Will use it.")
+    message(STATUS "  Homebrew ZSTD Includes: ${HOMEBREW_ZSTD_INCLUDE_DIRS}")
+    message(STATUS "  Homebrew ZSTD Link Libraries: ${HOMEBREW_ZSTD_LINK_LIBRARIES}")
+  else()
+    message(FATAL_ERROR "ZSTD not found")
+  endif ()
+
+  pkg_check_modules(HOMEBREW_JEMALLOC QUIET jemalloc)
+  if (HOMEBREW_JEMALLOC_FOUND)
+    set(JEMALLOC_LINK_LIBRARIES ${HOMEBREW_JEMALLOC_LINK_LIBRARIES})
+    message(STATUS "Apple Silicon: Found Homebrew Jemalloc. Will use it.")
+    message(STATUS "  Homebrew jemalloc Includes: ${HOMEBREW_JEMALLOC_INCLUDE_DIRS}")
+    message(STATUS "  Homebrew jemalloc Link Libraries: ${HOMEBREW_JEMALLOC_LINK_LIBRARIES}")
+  else()
+    message(WARNING "Apple Silicon: Homebrew jemalloc not found via pkg-config. Will try using default jemalloc.")
+  endif ()
+  message(STATUS "jemalloc Link Library: ${JEMALLOC_LINK_LIBRARIES}")
+else()
+  find_package(ZLIB REQUIRED)
+  find_package(ZSTD REQUIRED) # - needs recent versions of cmake
+endif ()
+
 
 # Preload the following libraries before running tests
 set(PRELOAD "libasan.so:libjemalloc.so.2")
@@ -112,6 +151,7 @@ message(STATUS "SMOOTHXG CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}")
 message(STATUS "SMOOTHXG CMAKE_CXX_FLAGS: ${CMAKE_CXX_FLAGS}")
 message(STATUS "SMOOTHXG CMAKE_C_FLAGS: ${CMAKE_C_FLAGS}")
 message(STATUS "SMOOTHXG CMAKE_EXE_LINKER_FLAGS: ${CMAKE_EXE_LINKER_FLAGS}")
+message(STATUS "SMOOTHXG CMAKE_SOURCE_DIR: ${CMAKE_SOURCE_DIR}")
 
 # Set the output folder
 set(CMAKE_BINARY_DIR ${CMAKE_SOURCE_DIR}/bin)
@@ -124,6 +164,7 @@ include_directories("${PROJECT_SOURCE_DIR}")
 # Add external projects
 include(${CMAKE_ROOT}/Modules/ExternalProject.cmake)
 
+set(CMAKE_ARGS "${CMAKE_ARGS};-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
 # libhandlegraph (full build using its cmake config)
 ExternalProject_Add(handlegraph
   SOURCE_DIR "${CMAKE_SOURCE_DIR}/deps/libhandlegraph"
@@ -164,6 +205,7 @@ set(random_dist_INCLUDE ${CMAKE_SOURCE_DIR}/deps/odgi/deps/cpp_random_distributi
 # mmmulti (memory mapped multimap)
 ExternalProject_Add(mmmulti
   SOURCE_DIR "${CMAKE_SOURCE_DIR}/deps/mmmulti"
+  CMAKE_ARGS "${CMAKE_ARGS}"
   BUILD_COMMAND ""
   UPDATE_COMMAND ""
   INSTALL_COMMAND ""
@@ -174,6 +216,7 @@ set(mmmulti_INCLUDE "${SOURCE_DIR}/src")
 # In-place Parallel Super Scalar Samplesort (IPS⁴o), header only
 ExternalProject_Add(ips4o
   SOURCE_DIR "${CMAKE_SOURCE_DIR}/deps/ips4o"
+  CMAKE_ARGS "${CMAKE_ARGS}"
   INSTALL_COMMAND ""
   BUILD_COMMAND ""
   CONFIGURE_COMMAND "")
@@ -183,6 +226,7 @@ set(ips4o_INCLUDE "${SOURCE_DIR}")
 # atomic queue library
 ExternalProject_Add(atomicqueue
   SOURCE_DIR "${CMAKE_SOURCE_DIR}/deps/atomic_queue"
+  CMAKE_ARGS "${CMAKE_ARGS}"
   UPDATE_COMMAND ""
   INSTALL_COMMAND ""
   BUILD_COMMAND ""
@@ -193,6 +237,7 @@ set(atomicqueue_INCLUDE "${SOURCE_DIR}/include/atomic_queue")
 # atomic bitvector class
 ExternalProject_Add(atomicbitvector
   SOURCE_DIR "${CMAKE_SOURCE_DIR}/deps/atomicbitvector"
+  CMAKE_ARGS "${CMAKE_ARGS}"
   UPDATE_COMMAND ""
   INSTALL_COMMAND ""
   BUILD_COMMAND ""
@@ -203,6 +248,7 @@ set(atomicbitvector_INCLUDE "${SOURCE_DIR}/include")
 # taywee's C++ args library, header only
 ExternalProject_Add(tayweeargs
   SOURCE_DIR "${CMAKE_SOURCE_DIR}/deps/args"
+  CMAKE_ARGS "${CMAKE_ARGS}"
   UPDATE_COMMAND ""
   INSTALL_COMMAND "")
 ExternalProject_Get_property(tayweeargs SOURCE_DIR)
@@ -225,6 +271,7 @@ set(gfakluge_LIB "${INSTALL_DIR}/src/gfakluge")
 # cgranges, header only
 ExternalProject_Add(cgranges
   SOURCE_DIR "${CMAKE_SOURCE_DIR}/deps/cgranges"
+  CMAKE_ARGS "${CMAKE_ARGS}"
   UPDATE_COMMAND ""
   INSTALL_COMMAND ""
   BUILD_COMMAND ""
@@ -243,6 +290,7 @@ set(libbf_LIB "${INSTALL_DIR}/lib")
 # dirtyzipf pow-approximate Zipf distribution
 ExternalProject_Add(dirtyzipf
         SOURCE_DIR "${CMAKE_SOURCE_DIR}/deps/odgi/deps/dirtyzipf"
+        CMAKE_ARGS "${CMAKE_ARGS}"
         UPDATE_COMMAND ""
         INSTALL_COMMAND ""
         BUILD_COMMAND ""
@@ -253,6 +301,7 @@ set(dirtyzipf_INCLUDE "${SOURCE_DIR}")
 # header-only pseudorandom number generator library
 ExternalProject_Add(xoshiro
   SOURCE_DIR "${CMAKE_SOURCE_DIR}/deps/odgi/deps/Xoshiro-cpp"
+  CMAKE_ARGS "${CMAKE_ARGS}"
   UPDATE_COMMAND ""
   INSTALL_COMMAND ""
   BUILD_COMMAND ""
@@ -262,6 +311,7 @@ set(xoshiro_INCLUDE "${SOURCE_DIR}")
 
 ExternalProject_Add(sautocorr
   SOURCE_DIR "${CMAKE_SOURCE_DIR}/deps/sautocorr"
+  CMAKE_ARGS "${CMAKE_ARGS}"
   UPDATE_COMMAND ""
   INSTALL_COMMAND ""
   BUILD_COMMAND ""
@@ -290,10 +340,12 @@ add_library(abpoa STATIC
     ${abpoa_SOURCE_DIR}/src/abpoa_simd.c
     ${abpoa_SOURCE_DIR}/src/simd_check.c
     ${abpoa_SOURCE_DIR}/src/utils.c)
+set(abPOA_INCLUDE "${CMAKE_SOURCE_DIR}/deps/abPOA/include")
 
 #add_subdirectory(deps/mmmulti/deps/mio)
 ExternalProject_Add(mio
   SOURCE_DIR "${CMAKE_SOURCE_DIR}/deps/mmmulti/deps/mio"
+  CMAKE_ARGS "${CMAKE_ARGS}"
   UPDATE_COMMAND ""
   INSTALL_COMMAND ""
   BUILD_COMMAND ""
@@ -304,6 +356,7 @@ set(mio_INCLUDE "${SOURCE_DIR}/include")
 # mkmh
 ExternalProject_Add(mkmh
   SOURCE_DIR "${CMAKE_SOURCE_DIR}/deps/mkmh"
+  CMAKE_ARGS "${CMAKE_ARGS}"
   UPDATE_COMMAND ""
   INSTALL_COMMAND ""
   BUILD_COMMAND ""
@@ -313,6 +366,7 @@ set(mkmh_INCLUDE "${SOURCE_DIR}")
 
 ExternalProject_Add(edlib
   SOURCE_DIR "${CMAKE_SOURCE_DIR}/deps/edlib"
+  CMAKE_ARGS "${CMAKE_ARGS}"
   UPDATE_COMMAND ""
   INSTALL_COMMAND ""
   BUILD_COMMAND ""
@@ -323,6 +377,7 @@ set(edlib_INCLUDE "${SOURCE_DIR}/edlib/include")
 
 ExternalProject_Add(xxHash
   SOURCE_DIR "${CMAKE_SOURCE_DIR}/deps/xxHash"
+  CMAKE_ARGS "${CMAKE_ARGS}"
   UPDATE_COMMAND ""
   INSTALL_COMMAND ""
   BUILD_COMMAND ""
@@ -425,25 +480,49 @@ set(smoothxg_INCLUDES
   "deps/WFA"
   "deps/patchmap")
 
+if (SMOOTHXG_USE_HOMEBREW_ZSTD_ON_APPLE_SILICON)
+  list(APPEND smoothxg_INCLUDES "${HOMEBREW_ZSTD_INCLUDE_DIRS}")
+endif()
+
 set(smoothxg_LIBS
   "${sdsl-lite_LIB}/libsdsl.a"
   "${sdsl-lite-divsufsort_LIB}/libdivsufsort.a"
   "${sdsl-lite-divsufsort_LIB}/libdivsufsort64.a"
   "${odgi_LIB}/libodgi.a"
   "${handlegraph_LIB}/libhandlegraph.a"
-  "-latomic"
-  wfa
+  wfa                                   # comment this line if manually linking wfa
+  "${JEMALLOC_LINK_LIBRARIES}"
   )
+
+# macOS does not need `-latomic` to use atomics.
+if (NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+  list(APPEND smoothxg_LIBS "-latomic")
+endif()
 
 target_include_directories(smoothxg_objs PUBLIC ${smoothxg_INCLUDES})
 
 add_executable(smoothxg
   $<TARGET_OBJECTS:smoothxg_objs>
   ${CMAKE_SOURCE_DIR}/src/main.cpp)
-target_link_libraries(smoothxg spoa abpoa)
+target_link_libraries(smoothxg spoa abpoa)        # comment this line if manually linking spoa and abpoa
 target_link_libraries(smoothxg ${smoothxg_LIBS})
 
-target_link_libraries(smoothxg z zstd jemalloc)
+if (SMOOTHXG_USE_HOMEBREW_ZSTD_ON_APPLE_SILICON)
+  target_include_directories(smoothxg PRIVATE ${HOMEBREW_ZSTD_INCLUDE_DIRS})
+  target_link_libraries(smoothxg -lz ${HOMEBREW_ZSTD_LINK_LIBRARIES})
+else()
+  target_link_libraries(smoothxg z zstd)
+endif()
+
+# Uncomment the below lines to manually link the deps that weren't explicitly installed in the above steps
+## Build abPOA and manually link lib; cd deps/abpoa &&  make
+#target_link_libraries(smoothxg "${CMAKE_SOURCE_DIR}/deps/abPOA/lib/libabpoa.a")
+#
+## Build SPOA and manually link lib; cd deps/spoa &&  cmake -B build -DCMAKE_BUILD_TYPE=Release &&  make -C build
+#target_link_libraries(smoothxg "${CMAKE_SOURCE_DIR}/deps/spoa/build/lib/libspoa.a")
+#
+## Build WFA and manually link Lib: cd deps/wfa && cmake -H. -Bbuild -DCMAKE_POLICY_VERSION_MINIMUM=3.5 && cmake --build build
+#target_link_libraries(smoothxg "${CMAKE_SOURCE_DIR}/deps/WFA/build/lib/libwfa.a")
 
 set_target_properties(smoothxg PROPERTIES OUTPUT_NAME "smoothxg")
 target_include_directories(smoothxg PUBLIC ${smoothxg_INCLUDES})

--- a/src/blocks.hpp
+++ b/src/blocks.hpp
@@ -9,7 +9,7 @@
 #include "mmmultimap.hpp"
 #include "xg.hpp"
 #include "flat_hash_map.hpp"
-#include "deps/odgi/src/dset64.hpp"
+#include "odgi/dset64.hpp"
 
 #include "tempfile.hpp"
 

--- a/src/breaks.cpp
+++ b/src/breaks.cpp
@@ -1,4 +1,4 @@
-#include <deps/odgi/src/odgi.hpp>
+#include "odgi/odgi.hpp"
 #include "breaks.hpp"
 #include "progress.hpp"
 #include "atomic_bitvector.hpp"

--- a/src/cleanup.cpp
+++ b/src/cleanup.cpp
@@ -41,7 +41,7 @@ void cleanup(
         = [&](const std::vector<handlegraph::path_handle_t> &path_sgd_use_paths, const xp::XP &path_index) {
               uint64_t max_path_step_count = 0;
               for (auto& path : path_sgd_use_paths) {
-                  max_path_step_count = std::max(max_path_step_count, path_index.get_path_step_count(path));
+                  max_path_step_count = std::max(max_path_step_count, static_cast<uint64_t>(path_index.get_path_step_count(path)));
               }
               return max_path_step_count;
           };

--- a/src/consensus_graph.cpp
+++ b/src/consensus_graph.cpp
@@ -1,4 +1,4 @@
-#include <deps/odgi/src/odgi.hpp>
+#include "odgi/odgi.hpp"
 #include "consensus_graph.hpp"
 
 namespace smoothxg {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,7 +8,7 @@
 #include <unistd.h>
 #include <iostream>
 #include <fstream>
-#include <deps/odgi/src/odgi.hpp>
+#include "odgi/odgi.hpp"
 #include "args.hxx"
 #include "sdsl/bit_vectors.hpp"
 #include "chain.hpp"
@@ -19,8 +19,7 @@
 #include "cleanup.hpp"
 #include "breaks.hpp"
 #include "utils.hpp"
-#include "deps/odgi/src/odgi.hpp"
-#include "deps/odgi/src/algorithms/xp.hpp"
+#include "odgi/xp.hpp"
 #include "consensus_graph.hpp"
 #include "rkmh.hpp"
 #include <chrono>
@@ -231,10 +230,10 @@ int main(int argc, char **argv) {
         xp::temp_file::set_dir(args::get(tmp_base));
         temp_file::set_dir(args::get(tmp_base));
     } else {
-        char* cwd = get_current_dir_name();
+        char cwd[512];
+        getcwd(cwd, sizeof(cwd));
         xp::temp_file::set_dir(std::string(cwd));
         temp_file::set_dir(std::string(cwd));
-        free(cwd);
     }
 
     if (!_read_consensus_path_names) {

--- a/src/prep.cpp
+++ b/src/prep.cpp
@@ -53,7 +53,7 @@ void prep(
         = [&](const std::vector<handlegraph::path_handle_t> &path_sgd_use_paths, const xp::XP &path_index) {
               uint64_t max_path_step_count = 0;
               for (auto& path : path_sgd_use_paths) {
-                  max_path_step_count = std::max(max_path_step_count, path_index.get_path_step_count(path));
+                  max_path_step_count = std::max(max_path_step_count, static_cast<uint64_t>(path_index.get_path_step_count(path)));
               }
               return max_path_step_count;
           };
@@ -63,7 +63,7 @@ void prep(
 			= [&](const std::vector<handlegraph::path_handle_t> &path_sgd_use_paths, const xp::XP &path_index) {
 				uint64_t max_path_length = std::numeric_limits<uint64_t>::min();
 				for (auto &path : path_sgd_use_paths) {
-					max_path_length = std::max(max_path_length, path_index.get_path_length(path));
+					max_path_length = std::max(max_path_length, static_cast<uint64_t>(path_index.get_path_length(path)));
 				}
 				return max_path_length;
 			};

--- a/src/tempfile.cpp
+++ b/src/tempfile.cpp
@@ -96,9 +96,9 @@ namespace temp_file {
 
         // Get the default temp dir from environment variables.
         if (temp_dir.empty()) {
-            char* cwd = get_current_dir_name();
+            char cwd[512];
+            getcwd(cwd, sizeof(cwd));
             temp_dir = std::string(cwd);
-            free(cwd);
             /*const char *system_temp_dir = nullptr;
             for (const char *var_name : {"TMPDIR", "TMP", "TEMP", "TEMPDIR", "USERPROFILE"}) {
                 if (system_temp_dir == nullptr) {


### PR DESCRIPTION
Successfully built SMOOTHXG on an M2 Mac Pro with these changes.

The primary errors that were seen:
1. Linking spoa, abpoa, and WFA. I had to build these dependencies manually and explicitly link the libraries in CMakeList.
2.  odgi headers were referenced from the installed files and the src (deps/odgi/src), leading to a definition conflict.
3. CMake has removed direct compatibility with versions older than 3.5 starting 4.0. This led to errors when version < 3.5 was specified in cmake_minimum_required. The fix was to add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 flag to override the minimum version.
4. jemalloc lib is usualy installed via homebrew on mac. Added support to identify and link homebrew libraries.
5. Removing GNUism and fixing typecast errors  


System Description:

```
cmake version 4.0.3

Homebrew clang version 17.0.6
Target: arm64-apple-darwin24.5.0
Thread model: posix
InstalledDir: /opt/homebrew/opt/llvm@17/bin

$CPPFLAGS
-I/opt/homebrew/opt/zlib/include -I/opt/homebrew/opt/libomp/include -I/opt/homebrew/opt/llvm@17/include

$LDFLAGS
-L/opt/homebrew/opt/zlib/lib -L/opt/homebrew/opt/libomp/lib -L/opt/homebrew/opt/llvm@17/lib

$PKG_CONFIG_PATH
/opt/homebrew/opt/zstd/lib/pkgconfig:/opt/homebrew/opt/zlib/lib/pkgconfig:/opt/homebrew/lib/pkgconfig:
```

--------
Other changes:

deps/WFA:

```
diff --git a/WFA/system/mm_allocator.cpp b/WFA/system/mm_allocator.cpp
index c574917..b472e94 100644
--- a/WFA/system/mm_allocator.cpp
+++ b/WFA/system/mm_allocator.cpp
@@ -257,7 +257,7 @@ void* mm_allocator_allocate(
 #endif
   if (segment != NULL) {
     // Allocate memory
-    void* const memory = segment->memory + segment->used;
+    void* const memory = (char*)segment->memory + segment->used;
     if (zero_mem) memset(memory,0,num_bytes); // Set zero
     // Set mm_reference
     mm_allocator_reference_t* const mm_reference = (mm_allocator_reference_t*)memory;
@@ -276,7 +276,7 @@ void* mm_allocator_allocate(
     // Update segment
     segment->used += num_bytes;
     // Return memory
-    return memory + sizeof(mm_allocator_reference_t);
+    return (char*)memory + sizeof(mm_allocator_reference_t);
   } else {
     // Allocate memory
     void* const memory = malloc(num_bytes);
@@ -286,7 +286,7 @@ void* mm_allocator_allocate(
     mm_allocator_reference_t* const mm_reference = (mm_allocator_reference_t*)memory;
     mm_reference->segment_idx = UINT32_MAX;
     // Return memory
-    return memory + sizeof(mm_allocator_reference_t);
+    return (char*)memory + sizeof(mm_allocator_reference_t);
   }
 }
 /*
@@ -355,7 +355,7 @@ void mm_allocator_free(
     mm_allocator_t* const mm_allocator,
     void* const memory) {
   // Get mm_reference
-  void* const effective_memory = memory - sizeof(mm_allocator_reference_t);
+  void* const effective_memory = (char*)memory - sizeof(mm_allocator_reference_t);
   mm_allocator_reference_t* const mm_reference = (mm_allocator_reference_t*)effective_memory;
   if (mm_reference->segment_idx == UINT32_MAX) {
     // Malloc memory
diff --git a/WFA/utils/vector.cpp b/WFA/utils/vector.cpp
index 204b378..5547699 100644
--- a/WFA/utils/vector.cpp
+++ b/WFA/utils/vector.cpp
@@ -66,7 +66,7 @@ void vector_reserve(vector_t* const vector,const uint64_t num_elements,const boo
     }
   }
   if (zero_mem) {
-    memset(vector->memory+vector->used*vector->element_size,0,
+    memset((char*)vector->memory+vector->used*vector->element_size,0,
         (vector->elements_allocated-vector->used)*vector->element_size);
   }
 }
```

deps/abPOA:
- Fixing Intel x86 SIMD intrinsics on ARM by explicitly using simde library headers referenced in deps/abpoa/include/simde

```
diff --git a/include/simd_instruction.h b/include/simd_instruction.h
index 16aebc7..95ff000 100644
--- a/include/simd_instruction.h
+++ b/include/simd_instruction.h

 #ifndef USE_SIMDE
-#include <immintrin.h>
+//#include <immintrin.h>
+#include "simde/simde/x86/sse2.h" # forcing to use simde library
 #else // use SIMDE
 #ifdef __AVX512BW__
 #include "simde/simde/x86/avx512.h"
@@ -282,8 +283,8 @@ typedef __m256i SIMDi; //for integers

 // start of SSE4.1 and SSE2
 // m128 will be our base type
-typedef __m128 SIMDf;   //for floats
-typedef __m128i SIMDi; //for integers
+typedef simde__m128 SIMDf;   //for floats
+typedef simde__m128i SIMDi; //for integers

 #define SIMDStore(x,y) _mm_store_ps(x,y)
 #define SIMDLoad(x) _mm_load_ps(x)
```


deps/sautocorr

```
diff --git a/sautocorr.cpp b/sautocorr.cpp
index b221c84..2ec44ba 100644
--- a/sautocorr.cpp
+++ b/sautocorr.cpp
@@ -11,7 +11,7 @@ repeat_t repeat(const std::vector<uint8_t>& vals,
                 const std::string& seq_name) {

     // bound max lag
-    max_lag = std::min(max_lag, vals.size()/2);
+    max_lag = std::min(max_lag, static_cast<uint64_t>(vals.size()/2));
     std::vector<double> autocorrs(max_lag - min_lag);
     double mean = vec_mean(vals.begin(), vals.end());
     double stdev = vec_stdev(vals.begin(), vals.end(), mean);
```
