### PR TITLE
Corrected mean coverage calculation

### DIFF
--- a/src/consensus_graph.cpp
+++ b/src/consensus_graph.cpp
@@ -137,7 +137,7 @@ odgi::graph_t* create_consensus_graph(const xg::XG &smoothed,
                     uint64_t depth = 0;
                     smoothed.for_each_step_on_handle(
                         handle, [&](const step_handle_t& s) { ++depth; });
-                    coverage += length * depth;
+                    coverage += handle_length * depth;
                 });
             consensus_mean_coverage[i] = (double)coverage / (double)length;
         }


### PR DESCRIPTION
## Description

Fixes a bug in the mean coverage calculation for the consensus graph where coverage was being inflated far beyond the expected range (i.e., approximately the number of input genomes at maximum).

## Root Cause

When accumulating `coverage` over each step in a consensus path, the code was multiplying `depth` by the cumulative path `length` rather than the current node's `handle_length`:

```cpp
coverage += length * depth;  // BUG: length grows with each step
```

Because `length` is a running total that increases with every step, it acted as an unintended multiplier, causing `coverage` to grow quadratically and the resulting mean to be many times higher than the true value.

## Fix

Use `handle_length` (the length of the current node) instead of the cumulative `length`:

```cpp
coverage += handle_length * depth;  // FIXED: uses only the current node's length
```

This correctly computes a coverage contribution proportional to each node's own length, so the final mean (`coverage / length`) reflects true depth in a range consistent with the number of input genomes (at maximum).