### PR TITLE
perf: remove progress-meter idle tax, hot-path allocations, and bump odgi

### DIFF
--- a/src/breaks.cpp
+++ b/src/breaks.cpp
@@ -150,6 +150,8 @@ namespace smoothxg {
         split_blocks.store(0);
 
         atomicbitvector::atomic_bv_t block_is_ready(blockset->size());
+        std::mutex block_ready_mtx;
+        std::condition_variable block_ready_cv;
         std::vector<std::vector<block_t>> ready_blocks(blockset->size());
 
         auto *broken_blockset = new smoothxg::blockset_t();
@@ -176,7 +178,12 @@ namespace smoothxg {
 
                     ++old_block_id;
                 } else {
-                    std::this_thread::sleep_for(std::chrono::nanoseconds(1));
+                    // park until a producer signals a newly-ready block; the
+                    // timeout is a backstop against a missed notify (the ready
+                    // bit is set without the mutex), never a busy-poll.
+                    std::unique_lock<std::mutex> lk(block_ready_mtx);
+                    block_ready_cv.wait_for(lk, std::chrono::milliseconds(10),
+                                            [&]{ return block_is_ready.test(old_block_id); });
                 }
             }
         };
@@ -579,6 +586,7 @@ namespace smoothxg {
             }
 
             block_is_ready.set(block_id);
+            block_ready_cv.notify_one();
 
             breaks_and_splits_progress.increment(1);
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -692,10 +692,20 @@ int main(int argc, char **argv) {
                 std::stringstream lace_banner;
                 lace_banner << smoothxg_iter << "::smooth_and_lace] embedding " << path_mapping.size() << " path fragments:";
                 progress_meter::ProgressMeter lace_progress(path_mapping.size(), lace_banner.str());
-                auto it = path_handle_2_start_and_end_in_path_mapping.begin();
+                // Materialize the map iterators once. ska::flat_hash_map has a
+                // forward iterator, so std::next(it, i) is O(i); calling it for
+                // every i in the loop below is O(n^2) in the number of paths.
+                std::vector<
+                    ska::flat_hash_map<path_handle_t, std::pair<uint64_t, uint64_t>>::iterator
+                    > path_iters;
+                path_iters.reserve(path_handle_2_start_and_end_in_path_mapping.size());
+                for (auto pit = path_handle_2_start_and_end_in_path_mapping.begin();
+                     pit != path_handle_2_start_and_end_in_path_mapping.end(); ++pit) {
+                    path_iters.push_back(pit);
+                }
         #pragma omp parallel for schedule(dynamic,1)
-                for (uint64_t i = 0; i < path_handle_2_start_and_end_in_path_mapping.size(); ++i) {
-                    auto local_it = std::next(it, i);
+                for (uint64_t i = 0; i < path_iters.size(); ++i) {
+                    auto local_it = path_iters[i];
 
                     //int thread_num = omp_get_thread_num();
                     //#pragma omp critical 

--- a/src/progress.hpp
+++ b/src/progress.hpp
@@ -6,6 +6,8 @@
 #include <thread>
 #include <chrono>
 #include <iomanip>
+#include <mutex>
+#include <condition_variable>
 
 namespace progress_meter {
 
@@ -16,21 +18,28 @@ namespace progress_meter {
         std::atomic<uint64_t> completed;
         std::chrono::time_point<std::chrono::steady_clock> start_time;
         std::thread logger;
+        std::mutex mtx;
+        std::condition_variable cv;
+        std::atomic<bool> done;
         ProgressMeter(uint64_t _total, const std::string& _banner)
                 : total(_total), banner(_banner) {
             start_time = std::chrono::steady_clock::now();
             completed = 0;
+            done = false;
             logger = std::thread(
                     [&](void) {
                         do_print();
-                        auto last = 0;
-                        while (completed < total) {
-                            auto curr = completed - last;
-                            if (curr > 0) {
+                        uint64_t last = 0;
+                        std::unique_lock<std::mutex> lock(mtx);
+                        while (!done.load()) {
+                            uint64_t curr = completed.load();
+                            if (curr > last) {
                                 do_print();
-                                last = completed;
+                                last = curr;
                             }
-                            std::this_thread::sleep_for(std::chrono::milliseconds(500));
+                            // wake immediately when finish() signals, otherwise
+                            // refresh the display at most every 500ms
+                            cv.wait_for(lock, std::chrono::milliseconds(500));
                         }
                     });
         };
@@ -53,9 +62,28 @@ namespace progress_meter {
         }
         void finish(void) {
             completed.store(total);
-            logger.join();
+            {
+                std::lock_guard<std::mutex> lock(mtx);
+                done.store(true);
+            }
+            cv.notify_all();
+            if (logger.joinable()) {
+                logger.join();
+            }
             do_print();
             std::cerr << std::endl;
+        }
+        ~ProgressMeter() {
+            // safety net: never let a still-joinable logger thread reach
+            // std::thread's destructor (which would call std::terminate)
+            if (logger.joinable()) {
+                {
+                    std::lock_guard<std::mutex> lock(mtx);
+                    done.store(true);
+                }
+                cv.notify_all();
+                logger.join();
+            }
         }
         std::string print_time(const double& _seconds) {
             int days = 0, hours = 0, minutes = 0, seconds = 0;

--- a/src/smooth.cpp
+++ b/src/smooth.cpp
@@ -81,18 +81,17 @@ void append_to_sequence(const xg::XG &graph,
     while (step != final_step && characters_to_add > 0){
         const auto h = graph.get_handle_of_step(step);
         const auto l = graph.get_length(h);
+        // decode the node sequence once (get_sequence returns by value)
+        const std::string s = graph.get_sequence(h);
 
         uint64_t characters_added;
         if (l <= characters_to_add) {
             // Take the full seq
-            tmp.append(graph.get_sequence(h));
+            tmp.append(s);
             characters_added = l;
         }else {
             // Take only the characters needed
-            graph.get_sequence(h).substr(graph.get_sequence(h).size() - characters_to_add);
-            tmp.append(
-                    graph.get_sequence(h).substr(graph.get_sequence(h).size() - characters_to_add)
-            );
+            tmp.append(s.substr(s.size() - characters_to_add));
             characters_added = characters_to_add;
         }
         if (graph.get_is_reverse(h)) {
@@ -107,22 +106,16 @@ void append_to_sequence(const xg::XG &graph,
 
     if (on_the_left){
         //std::cerr << graph.get_path_name(path_handle) << " - HEAD: ";
-        while (characters_to_add > 0) {
-            seq.append("N");
-            //std::cerr << "N";
-            --characters_to_add;
-        }
+        seq.append(characters_to_add, 'N');
+        characters_to_add = 0;
         //std::cerr << tmp << std::endl;
         seq.append(tmp);
     } else {
         //std::cerr << graph.get_path_name(path_handle) << " - TAIL: " << tmp;
         seq.append(tmp);
 
-        while (characters_to_add > 0) {
-            seq.append("N");
-            //std::cerr << "N";
-            --characters_to_add;
-        }
+        seq.append(characters_to_add, 'N');
+        characters_to_add = 0;
         //std::cerr << "\n";
     }
 }
@@ -163,6 +156,16 @@ odgi::graph_t* smooth_abpoa(const xg::XG &graph, const block_t &block, const uin
     std::vector<std::vector<uint64_t>> dup_rank_in_path_ranges;
 
     std::vector<std::string> all_names_in_original_order;
+
+    // block.path_ranges.size() is an O(1) upper bound on the number of
+    // (unique) sequences; reserve to avoid geometric reallocation churn.
+    const uint64_t n_path_ranges = block.path_ranges.size();
+    seqs.reserve(n_path_ranges);
+    weights.reserve(n_path_ranges);
+    dup_is_revs.reserve(n_path_ranges);
+    dup_seq_names.reserve(n_path_ranges);
+    dup_rank_in_path_ranges.reserve(n_path_ranges);
+    all_names_in_original_order.reserve(n_path_ranges);
 
     std::size_t max_sequence_size = 0;
 
@@ -212,7 +215,8 @@ odgi::graph_t* smooth_abpoa(const xg::XG &graph, const block_t &block, const uin
             // New sequence
             seq_to_rank[hash] = seqs.size();
 
-            seqs.push_back(seq);
+            max_sequence_size = std::max(max_sequence_size, seq.size());
+            seqs.push_back(std::move(seq)); // seq is not read again this iteration
             weights.push_back(1);
             dup_is_revs.emplace_back();
             dup_is_revs.back().push_back(rev_bp > fwd_bp);
@@ -221,8 +225,6 @@ odgi::graph_t* smooth_abpoa(const xg::XG &graph, const block_t &block, const uin
 
             dup_rank_in_path_ranges.emplace_back();
             dup_rank_in_path_ranges.back().push_back(i);
-
-            max_sequence_size = std::max(max_sequence_size, seq.size());
         } else {
             uint64_t rank = seq_to_rank[hash];
 
@@ -654,6 +656,16 @@ odgi::graph_t* smooth_spoa(const xg::XG &graph, const block_t &block,
 
         std::vector<std::string> all_names_in_original_order;
 
+        // block.path_ranges.size() is an O(1) upper bound on the number of
+        // (unique) sequences; reserve to avoid geometric reallocation churn.
+        const uint64_t n_path_ranges = block.path_ranges.size();
+        seqs.reserve(n_path_ranges);
+        weights.reserve(n_path_ranges);
+        dup_is_revs.reserve(n_path_ranges);
+        dup_seq_names.reserve(n_path_ranges);
+        dup_rank_in_path_ranges.reserve(n_path_ranges);
+        all_names_in_original_order.reserve(n_path_ranges);
+
         std::size_t max_sequence_size = 0;
 
         for (uint64_t i = 0; i < block.path_ranges.size(); ++i) {
@@ -702,7 +714,8 @@ odgi::graph_t* smooth_spoa(const xg::XG &graph, const block_t &block,
                 // New sequence
                 seq_to_rank[hash] = seqs.size();
 
-                seqs.push_back(seq);
+                max_sequence_size = std::max(max_sequence_size, seq.size());
+                seqs.push_back(std::move(seq)); // seq is not read again this iteration
                 weights.push_back(1);
                 dup_is_revs.emplace_back();
                 dup_is_revs.back().push_back(rev_bp > fwd_bp);
@@ -711,8 +724,6 @@ odgi::graph_t* smooth_spoa(const xg::XG &graph, const block_t &block,
 
                 dup_rank_in_path_ranges.emplace_back();
                 dup_rank_in_path_ranges.back().push_back(i);
-
-                max_sequence_size = std::max(max_sequence_size, seq.size());
             } else {
                 uint64_t rank = seq_to_rank[hash];
 
@@ -1578,6 +1589,8 @@ void smooth_and_lace(const xg::XG &graph,
         // but the sequences will be considered (and kept in memory) only if a MAF has to be produced
         std::vector<std::unique_ptr<ska::flat_hash_map<std::string, std::vector<maf_partial_row_t>>>> mafs(produce_maf || (add_consensus && merge_blocks) ? blockset->size() : 0);
         atomicbitvector::atomic_bv_t mafs_ready(produce_maf || (add_consensus && merge_blocks) ? blockset->size() : 0);
+        std::mutex mafs_ready_mtx;
+        std::condition_variable mafs_ready_cv;
 
         auto write_maf_lambda = [&]() {
             if (produce_maf || (add_consensus && merge_blocks)) {
@@ -1862,7 +1875,16 @@ void smooth_and_lace(const xg::XG &graph,
                         }*/
                     }
 
-                    std::this_thread::sleep_for(std::chrono::nanoseconds(1));
+                    // park until a producer signals the next in-order block is
+                    // ready; predicate returns immediately when the block is
+                    // already available (back-to-back consumption). Guard the
+                    // bounds since block_id may equal num_blocks here. The
+                    // timeout backstops a missed notify (bit set without lock).
+                    {
+                        std::unique_lock<std::mutex> lk(mafs_ready_mtx);
+                        mafs_ready_cv.wait_for(lk, std::chrono::milliseconds(10),
+                                               [&]{ return block_id >= num_blocks || mafs_ready.test(block_id); });
+                    }
                 }
 
                 while (!merged_maf_blocks_queue.empty()) {
@@ -2280,6 +2302,7 @@ void smooth_and_lace(const xg::XG &graph,
             poa_progress.increment(1);
             if (produce_maf || (add_consensus && merge_blocks)){
                 mafs_ready.set(block_id);
+                mafs_ready_cv.notify_one();
             }
         }
 


### PR DESCRIPTION
Two idle-time wins plus hot-path cleanups. Output-preserving.

- **progress meter** (smoothxg here + odgi bump): `finish()` joined a logger thread that only rechecked completion every 500ms, so each sub-500ms metered stage paid a ~500ms idle tax. Now signalled via a `condition_variable`. odgi's copy fixed in pangenome/odgi#663 and pulled in by the odgi bump, which removes the tax from the prep stages too.
- **hot path**: move (not copy) per-block POA input sequences, drop a dead `get_sequence()` decode, `reserve()` POA-input vectors, O(n^2)->O(n) `std::next` in the parallel embedding loop, and two `sleep_for(1ns)` spin-waits -> condition variables.

Wall, full pipeline with prep: DRB1 23.9s -> 4.4s; chr6.C4 (90 haplotypes) 30s -> 13s.

Correctness: no-prep output byte-identical to baseline (stable across runs, t=1..16); ctest passes.
