### PR TITLE
maf: compare against spoa's gap character when trimming the POA padding

### DIFF
--- a/src/smooth.cpp
+++ b/src/smooth.cpp
@@ -5,6 +5,11 @@
 
 namespace smoothxg {
 
+// spoa's GenerateMultipleSequenceAlignment returns ASCII rows gapped with '-',
+// unlike abPOA's msa_base, which is numerically encoded with 5 for a gap. The
+// padding removal below runs on the spoa rows, so it has to test for '-'.
+static const char GAP_CHAR = '-';
+
 /*
 void _clear_maf_block(ska::flat_hash_map<std::string, std::vector<maf_partial_row_t>> &maf){
     for (const auto &path_to_maf_rows : maf){
@@ -787,8 +792,8 @@ odgi::graph_t* smooth_spoa(const xg::XG &graph, const block_t &block,
                 int j = 0;
                 uint64_t characters_to_remove = poa_padding;
                 while (characters_to_remove > 0) {
-                    if (msa[i][j] != 5){
-                        msa[i][j] = 5;
+                    if (msa[i][j] != GAP_CHAR){
+                        msa[i][j] = GAP_CHAR;
                         --characters_to_remove;
                     }
 
@@ -799,8 +804,8 @@ odgi::graph_t* smooth_spoa(const xg::XG &graph, const block_t &block,
                 characters_to_remove = poa_padding;
                 while (characters_to_remove > 0) {
                     --j;
-                    if (msa[i][j] != 5){
-                        msa[i][j] = 5;
+                    if (msa[i][j] != GAP_CHAR){
+                        msa[i][j] = GAP_CHAR;
                         --characters_to_remove;
                     }
                 }
@@ -812,7 +817,7 @@ odgi::graph_t* smooth_spoa(const xg::XG &graph, const block_t &block,
                 int i = 0;
                 // Find a non-gap character in the current MSA-column
                 for (; i < msa.size(); ++i) {
-                    if (msa[i][start_pos_to_trim] != 5){
+                    if (msa[i][start_pos_to_trim] != GAP_CHAR){
                         break;
                     }
                 }
@@ -829,7 +834,7 @@ odgi::graph_t* smooth_spoa(const xg::XG &graph, const block_t &block,
                 int i = 0;
                 // Find a non-gap character in the current MSA-column
                 for (; i < msa.size(); ++i) {
-                    if (msa[i][end_pos_to_trim] != 5){
+                    if (msa[i][end_pos_to_trim] != GAP_CHAR){
                         break;
                     }
                 }


### PR DESCRIPTION
The MAF written by `-m/--maf` keeps the POA padding in the sequence field, so a
row's non-gap count disagrees with its `size`. On the five-strain E. coli graph
below, 20,479 of 27,612 rows are affected, most of them by exactly 311 bases.

`start` and `size` are right — they describe the unpadded interval — so the MAF
spec's own definition of `size` ("equal to the number of non-dash characters in
the alignment text field") is what breaks, and a consumer that trusts either
field gets the wrong answer.

## Cause

`smooth_spoa` blanks each row's padding before writing the MAF, and the loop is
correct in `smooth_abpoa`, where the MSA is abPOA's numeric encoding and `5` is
the gap:

```cpp
if (ab->abc->msa_base[i][j] != 5) { ab->abc->msa_base[i][j] = 5; --characters_to_remove; }
```

`smooth_spoa` reuses that loop on `poa_graph.GenerateMultipleSequenceAlignment()`,
which returns ASCII rows gapped with `'-'` (spoa's `graph.cpp`:
`std::string row(row_size, '-')`):

```cpp
if (msa[i][j] != 5) { msa[i][j] = 5; --characters_to_remove; }
```

ASCII 5 is ENQ, so `!= 5` is always true. The loop then counts *characters*
rather than *bases* — gaps included — and writes `\x05` in place of a gap. The
net effect is that a fixed `poa_padding` columns come off each end instead of
`poa_padding` bases off each row, so the padding survives wherever a row is
gapped in that stretch. The same comparison is used by the two trim scans just
below it.

SPOA is the default, and `pggb` does not pass `-A`, so this is the path almost
everyone gets.

## Why it is worth fixing

Each sequence is padded on both ends, so on a row antiparallel to the block's
first row the leftover padding lands at the opposite end of the alignment. The
block has to gap it, and a consumer reading indels off the columns sees a
phantom insertion — one per POA block, at the `poa-length-target` stride.

`K12:2,120,000-2,140,000` of a five-strain E. coli pggb graph in a genome
browser. Same graph, same parameters, same locus — only the smoothxg binary
differs between the two.

### Before — smoothxg as-is

Boxed in red: a phantom ~311 bp insertion at nearly every POA block edge on
IAI39, the one strain inverted against K12 here. The coverage histogram above
the rows doubles over the same padding.

![before, smoothxg as-is](https://jbrowse.org/demos/ecoli_pangenome/smoothxg_padding_demo/before.png)

### After — with this patch

The insertions are gone and the coverage histogram is flat. Per-sample union
coverage is byte-identical to the panel above.

![after, with this patch](https://jbrowse.org/demos/ecoli_pangenome/smoothxg_padding_demo/after.png)

Both MAFs and the browser config are hosted beside these images, so the
comparison can be opened live rather than taken from a picture.

## Fix

Test for and write spoa's own gap character.

## Verification

Two public sequences and one `pggb` command, ~2 minutes:

```bash
datasets download genome accession GCF_000005845.2 --include genome --filename K12.zip
datasets download genome accession GCF_000026345.1 --include genome --filename IAI39.zip
unzip -p K12.zip   'ncbi_dataset/data/*/*_genomic.fna' > K12.fa   && samtools faidx K12.fa
unzip -p IAI39.zip 'ncbi_dataset/data/*/*_genomic.fna' > IAI39.fa && samtools faidx IAI39.fa

samtools faidx K12.fa   NC_000913.3:2100000-2160000 | sed '1s/.*/>K12sub#1#chr/'   > in.fa
samtools faidx IAI39.fa NC_011750.1:1000000-1055000 | sed '1s/.*/>IAI39sub#1#chr/' >> in.fa
bgzip -k in.fa && samtools faidx in.fa.gz

pggb -i in.fa.gz -o out -n 2 -t 8 -p 90 -s 5000 -M
```

```python
import glob
bad = tot = 0
for line in open(glob.glob('out/*.smooth.maf')[0]):
    if line[:1] == 's':
        f = line.split(); tot += 1
        if len(f[6]) - f[6].count('-') != int(f[3]):
            bad += 1
print(tot, 'rows,', bad, 'where the non-gap count != size')
```

On that input, and on the five-strain graph from the screenshot:

| | rows | `size` != non-gap | >=100 bp reference-gap runs filled by another row |
|---|---|---|---|
| 2-sequence, before | 111 | 82 | 43 |
| 2-sequence, after | 111 | **0** | 6 |
| 5-strain, before | 27,612 | 20,479 | 4,518 |
| 5-strain, after | 26,710 | **0** | 1,244 |

Union coverage per sample is byte-identical before and after on the five-strain
graph (K12 4,641,652, Sakai 5,498,578, CFT073 5,231,428, NCTC86 5,111,920,
IAI39 5,132,068), so nothing real is dropped — the rows that disappear are ones
whose only content was padding.

Three independent checks agree that the padding is the cause, all on the
2-sequence input:

- `-O 0 -Y 0` (no padding at all): 0 non-conforming rows.
- `-O 0.001 -Y 0` (no adaptive pad, only the ratio pad): the surplus drops from
  311 to exactly 1, which is `average block sequence length ~1100 * 0.001`.
- `-A` (abPOA, whose branch already compares correctly): 0 non-conforming rows,
  with padding fully enabled.

Built against `9efd2e6` in the `pggb:202603141454453ade6b` image (Debian 12,
gcc 12); the before/after binaries in the table differ only by this commit.

---

The investigation and this patch were produced with Claude Code. Every number
above comes from the commands in this description rather than from the model, so
please re-run them rather than taking them on trust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
